### PR TITLE
feat(preset): add destructive color CSS variables

### DIFF
--- a/packages/preset/src/_style/vars.css
+++ b/packages/preset/src/_style/vars.css
@@ -40,6 +40,9 @@
   --una-sidebar-accent-foreground: var(--una-gray-800);
   --una-sidebar-border: var(--una-gray-200);
   --una-sidebar-ring: var(--una-gray-200);
+
+  --una-destructive: 239, 68, 68;
+  --una-destructive-foreground: 255, 255, 255;
 }
 
 .dark {
@@ -75,4 +78,7 @@
   --una-sidebar-accent-foreground: var(--una-gray-100);
   --una-sidebar-border: var(--una-gray-700);
   --una-sidebar-ring: var(--una-gray-700);
+
+  --una-destructive: 239, 68, 68;
+  --una-destructive-foreground: 255, 255, 255;
 }

--- a/packages/preset/src/index.ts
+++ b/packages/preset/src/index.ts
@@ -74,6 +74,10 @@ export default function presetUna(options: unaUIOptions = {
         success: colors.green,
         warning: colors.amber,
         info: colors.blue,
+        destructive: {
+          DEFAULT: 'rgba(var(--una-destructive) / <alpha-value>)',
+          foreground: 'rgba(var(--una-destructive-foreground) / <alpha-value>)',
+        },
       },
       borderRadius: {
         xl: 'calc(var(--una-radius) + 4px)',


### PR DESCRIPTION
## Description

This PR implements #436 by adding destructive color CSS variables to the Una UI preset.

### Changes

- **\[packages/preset/src/_style/vars.css\](cci:7://file:///home/louis/una-ui/packages/preset/src/_style/vars.css:0:0-0:0)**: Added \`--una-destructive\` and \`--una-destructive-foreground\` CSS variables for both light and dark modes
- **\[packages/preset/src/index.ts\](cci:7://file:///home/louis/una-ui/packages/preset/src/index.ts:0:0-0:0)**: Added \`destructive\` color configuration to UnoCSS theme

### New Utility Classes Available

After this change, users can use:
- \`bg-destructive\` - Destructive action background color
- \`text-destructive\` - Destructive action text color  
- \`text-destructive-foreground\` - Text color on destructive background
- \`border-destructive\` - Destructive action border color
- And more...

### Color Values

| Variable | Value | Description |
|----------|-------|-------------|
| \`--una-destructive\` | \`rgb(239, 68, 68)\` | Red-500, used for destructive backgrounds |
| \`--una-destructive-foreground\` | \`rgb(255, 255, 255)\` | White, for text on destructive backgrounds |

Closes #436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new destructive color palette for both light and dark themes, enabling consistent styling across destructive actions and warning UI elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->