### PR TITLE
feat(form): update vee-validate to v5

### DIFF
--- a/docs/components/content/examples/vue/combobox/ExampleVueComboboxFormField.vue
+++ b/docs/components/content/examples/vue/combobox/ExampleVueComboboxFormField.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
-import { toTypedSchema } from '@vee-validate/zod'
 import * as z from 'zod'
 
-const formSchema = toTypedSchema(z.object({
+const formSchema = z.object({
   framework: z.object({
     value: z.string().min(1, 'This field is required'),
     label: z.string().min(1, 'This field is required'),
   }),
-}))
+})
 
 useForm({
   validationSchema: formSchema,

--- a/docs/components/content/examples/vue/form/ExampleVueFormBasic.vue
+++ b/docs/components/content/examples/vue/form/ExampleVueFormBasic.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { toTypedSchema } from '@vee-validate/zod'
 import * as z from 'zod'
 
-const formSchema = toTypedSchema(z.object({
+const formSchema = z.object({
   username: z.string().min(2).max(50),
   password: z.string().min(6).max(50),
   note: z.string(),
@@ -15,7 +14,7 @@ const formSchema = toTypedSchema(z.object({
   notifications: z.boolean(),
   enabled: z.boolean(),
   slider: z.array(z.number().max(40, { message: 'Must be less than 40' })),
-}))
+})
 
 const { handleSubmit, validate, errors } = useForm({
   validationSchema: formSchema,

--- a/docs/components/content/examples/vue/number-field/ExampleVueNumberFieldForm.vue
+++ b/docs/components/content/examples/vue/number-field/ExampleVueNumberFieldForm.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import * as z from 'zod'
 
-const formSchema = toTypedSchema(z.object({
+const formSchema = z.object({
   payment: z.number().min(10, 'Min 10 euros to send payment').max(5000, 'Max 5000 euros to send payment'),
-}))
+})
 
 const { handleSubmit, setFieldValue } = useForm({
   validationSchema: formSchema,

--- a/docs/components/content/examples/vue/pin-input/ExampleVuePinInputForm.vue
+++ b/docs/components/content/examples/vue/pin-input/ExampleVuePinInputForm.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { toTypedSchema } from '@vee-validate/zod'
 import * as z from 'zod'
 
-const formSchema = toTypedSchema(z.object({
+const formSchema = z.object({
   pin: z.array(z.string()).min(6, 'This field is required'),
-}))
+})
 
 useForm({
   validationSchema: formSchema,

--- a/docs/components/content/examples/vue/select/ExampleVueSelectForm.vue
+++ b/docs/components/content/examples/vue/select/ExampleVueSelectForm.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { toTypedSchema } from '@vee-validate/zod'
 import * as z from 'zod'
 
-const formSchema = toTypedSchema(z.object({
+const formSchema = z.object({
   contributor: z.string().min(1, 'This field is required'),
-}))
+})
 
 useForm({
   validationSchema: formSchema,

--- a/docs/content/3.components/form.md
+++ b/docs/content/3.components/form.md
@@ -6,7 +6,7 @@ badges:
     to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/forms/form.vue
     target: _blank
   - value: API reference
-    to: https://vee-validate.logaretm.com/v4/guide/overview
+    to: https://vee-validate.logaretm.com/v5/guide/overview
     target: _blank
 ---
 

--- a/docs/content/3.components/form.md
+++ b/docs/content/3.components/form.md
@@ -10,6 +10,11 @@ badges:
     target: _blank
 ---
 
+::alert{type="tip"}
+Remember to install your chosen validator as a dependency. Zod is recommended, but you
+can use any validation library implementing [standardschemas](https://standardschema.dev/).
+::
+
 ## Examples
 
 ### Basic

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,8 +39,6 @@
     "@iconify-json/vscode-icons": "catalog:",
     "@nuxt/devtools": "catalog:",
     "@una-ui/content": "catalog:",
-    "@vee-validate/nuxt": "catalog:",
-    "@vee-validate/zod": "catalog:",
     "@vueuse/core": "catalog:",
     "nuxt": "catalog:",
     "zod": "catalog:"

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -56,7 +56,6 @@
     "@unocss/preset-icons": "catalog:",
     "@unocss/reset": "catalog:",
     "@vee-validate/nuxt": "catalog:",
-    "@vee-validate/zod": "catalog:",
     "@vueuse/core": "catalog:",
     "@vueuse/integrations": "catalog:",
     "@vueuse/nuxt": "catalog:",

--- a/packages/nuxt/playground/pages/components/forms.vue
+++ b/packages/nuxt/playground/pages/components/forms.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { toTypedSchema } from '@vee-validate/zod'
 import * as z from 'zod'
 
-const formSchema = toTypedSchema(z.object({
+const formSchema = z.object({
   username: z.string().min(2).max(50),
   password: z.string().min(6).max(50),
   note: z.string(),
@@ -15,7 +14,7 @@ const formSchema = toTypedSchema(z.object({
   notifications: z.boolean(),
   enabled: z.boolean(),
   slider: z.array(z.number().max(40, { message: 'Must be less than 40' })),
-}))
+})
 
 const { handleSubmit, validate, errors } = useForm({
   validationSchema: formSchema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,11 +94,8 @@ catalogs:
       specifier: ^66.5.10
       version: 66.5.10
     '@vee-validate/nuxt':
-      specifier: ^4.15.1
-      version: 4.15.1
-    '@vee-validate/zod':
-      specifier: ^4.15.1
-      version: 4.15.1
+      specifier: ^5.0.0-beta.1
+      version: 5.0.0-beta.1
     '@vercel/analytics':
       specifier: ^1.6.1
       version: 1.6.1
@@ -214,8 +211,8 @@ catalogs:
       specifier: ^2.2.12
       version: 2.2.12
     zod:
-      specifier: ^3.25.76
-      version: 3.25.76
+      specifier: ^4.3.6
+      version: 4.3.6
 
 overrides:
   '@una-ui/content>@una-ui/nuxt': workspace:./packages/nuxt
@@ -250,7 +247,7 @@ importers:
         version: 66.5.10(@unocss/webpack@66.5.10(webpack@5.99.9(esbuild@0.25.9)))(postcss@8.5.6)(vite@7.1.7(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.2))
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.3.6
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -354,12 +351,6 @@ importers:
       '@una-ui/content':
         specifier: 'catalog:'
         version: 48.3.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.11)(@unhead/vue@2.0.14(vue@3.5.21(typescript@5.6.3)))(@unocss/webpack@66.5.10(webpack@5.99.9(esbuild@0.25.9)))(@vue/compiler-sfc@3.5.28)(db0@0.3.2)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.8.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(postcss@8.5.6)(rollup@4.52.2)(sass@1.97.3)(terser@5.40.0)(tsx@4.19.4)(unstorage@1.17.1(@netlify/blobs@9.1.2)(db0@0.3.2)(ioredis@5.8.0))(vite@7.1.7(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.6.3))(yaml@2.8.2)
-      '@vee-validate/nuxt':
-        specifier: 'catalog:'
-        version: 4.15.1(magicast@0.5.2)(vue@3.5.21(typescript@5.6.3))
-      '@vee-validate/zod':
-        specifier: 'catalog:'
-        version: 4.15.1(vue@3.5.21(typescript@5.6.3))(zod@3.25.76)
       '@vueuse/core':
         specifier: 'catalog:'
         version: 12.8.2(typescript@5.6.3)
@@ -368,7 +359,7 @@ importers:
         version: 3.19.2(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.11)(@vue/compiler-sfc@3.5.28)(db0@0.3.2)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.8.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup@4.52.2)(sass@1.97.3)(terser@5.40.0)(tsx@4.19.4)(typescript@5.6.3)(vite@7.1.7(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.6.3))(yaml@2.8.2)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.3.6
 
   packages/extractor-vue-script:
     dependencies:
@@ -432,10 +423,7 @@ importers:
         version: 66.5.10
       '@vee-validate/nuxt':
         specifier: 'catalog:'
-        version: 4.15.1(magicast@0.3.5)(vue@3.5.21(typescript@5.8.3))
-      '@vee-validate/zod':
-        specifier: 'catalog:'
-        version: 4.15.1(vue@3.5.21(typescript@5.8.3))(zod@3.25.76)
+        version: 5.0.0-beta.1(magicast@0.3.5)(vue@3.5.21(typescript@5.8.3))
       '@vueuse/core':
         specifier: 'catalog:'
         version: 12.8.2(typescript@5.8.3)
@@ -493,7 +481,7 @@ importers:
         version: 3.19.2(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.19.11)(@vue/compiler-sfc@3.5.28)(db0@0.3.2)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.8.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.52.2)(sass@1.97.3)(terser@5.40.0)(tsx@4.19.4)(typescript@5.8.3)(vite@7.1.7(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3))(yaml@2.8.2)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.3.6
 
   packages/preset:
     dependencies:
@@ -1963,6 +1951,12 @@ packages:
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@stylistic/eslint-plugin@5.4.0':
     resolution: {integrity: sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2299,13 +2293,8 @@ packages:
     peerDependencies:
       webpack: ^4 || ^5
 
-  '@vee-validate/nuxt@4.15.1':
-    resolution: {integrity: sha512-vy+BYUmwy7d01js8jg3qApyrE8/nJHbHvPZNYZSe+hTQEblNqyVt+MnD1incyxMCcivED8FX5w4rjxdoUn7iMQ==}
-
-  '@vee-validate/zod@4.15.1':
-    resolution: {integrity: sha512-329Z4TDBE5Vx0FdbA8S4eR9iGCFFUNGbxjpQ20ff5b5wGueScjocUIx9JHPa79LTG06RnlUR4XogQsjN4tecKA==}
-    peerDependencies:
-      zod: ^3.24.0
+  '@vee-validate/nuxt@5.0.0-beta.1':
+    resolution: {integrity: sha512-JfxJIROk7AeoLVlxgeaY/KjXbubZxhcqSWoVq8SYBO7qd4n+XxRKs5nNoPfvYdVBWN4s9cu+6AjmUerRBeWdDQ==}
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -6476,8 +6465,8 @@ packages:
       reka-ui: ^2.0.0
       vue: ^3.3.0
 
-  vee-validate@4.15.1:
-    resolution: {integrity: sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==}
+  vee-validate@5.0.0-beta.1:
+    resolution: {integrity: sha512-Z9cyGtupC5L+9zBzrcw59OFAnHeWJUL/On2fbLSioRo1Evc717xbnx4oPYbH59VvUegYQ1hJZPregAAcH45KOA==}
     peerDependencies:
       vue: ^3.4.26
 
@@ -6851,8 +6840,8 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8700,6 +8689,10 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
+
   '@stylistic/eslint-plugin@5.4.0(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
@@ -9298,38 +9291,13 @@ snapshots:
       webpack: 5.99.9(esbuild@0.25.9)
       webpack-sources: 3.3.3
 
-  '@vee-validate/nuxt@4.15.1(magicast@0.3.5)(vue@3.5.21(typescript@5.8.3))':
+  '@vee-validate/nuxt@5.0.0-beta.1(magicast@0.3.5)(vue@3.5.21(typescript@5.8.3))':
     dependencies:
       '@nuxt/kit': 3.20.0(magicast@0.3.5)
       local-pkg: 0.5.1
-      vee-validate: 4.15.1(vue@3.5.21(typescript@5.8.3))
+      vee-validate: 5.0.0-beta.1(vue@3.5.21(typescript@5.8.3))
     transitivePeerDependencies:
       - magicast
-      - vue
-
-  '@vee-validate/nuxt@4.15.1(magicast@0.5.2)(vue@3.5.21(typescript@5.6.3))':
-    dependencies:
-      '@nuxt/kit': 3.20.0(magicast@0.5.2)
-      local-pkg: 0.5.1
-      vee-validate: 4.15.1(vue@3.5.21(typescript@5.6.3))
-    transitivePeerDependencies:
-      - magicast
-      - vue
-
-  '@vee-validate/zod@4.15.1(vue@3.5.21(typescript@5.6.3))(zod@3.25.76)':
-    dependencies:
-      type-fest: 4.41.0
-      vee-validate: 4.15.1(vue@3.5.21(typescript@5.6.3))
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - vue
-
-  '@vee-validate/zod@4.15.1(vue@3.5.21(typescript@5.8.3))(zod@3.25.76)':
-    dependencies:
-      type-fest: 4.41.0
-      vee-validate: 4.15.1(vue@3.5.21(typescript@5.8.3))
-      zod: 3.25.76
-    transitivePeerDependencies:
       - vue
 
   '@vercel/analytics@1.6.1(vue-router@4.5.1(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))':
@@ -14745,14 +14713,10 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vee-validate@4.15.1(vue@3.5.21(typescript@5.6.3)):
+  vee-validate@5.0.0-beta.1(vue@3.5.21(typescript@5.8.3)):
     dependencies:
-      '@vue/devtools-api': 7.7.6
-      type-fest: 4.41.0
-      vue: 3.5.21(typescript@5.6.3)
-
-  vee-validate@4.15.1(vue@3.5.21(typescript@5.8.3)):
-    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
       '@vue/devtools-api': 7.7.6
       type-fest: 4.41.0
       vue: 3.5.21(typescript@5.8.3)
@@ -15186,6 +15150,6 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod@3.25.76: {}
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,8 +37,7 @@ catalog:
   '@unocss/preset-mini': ^66.5.10
   '@unocss/preset-uno': ^66.5.10
   '@unocss/reset': ^66.5.10
-  '@vee-validate/nuxt': ^4.15.1
-  '@vee-validate/zod': ^4.15.1
+  '@vee-validate/nuxt': ^5.0.0-beta.1
   '@vercel/analytics': ^1.6.1
   '@vue/compiler-core': ^3.5.28
   '@vue/compiler-sfc': ^3.5.28
@@ -77,4 +76,4 @@ catalog:
   vaul-vue: ^0.4.1
   vitest: ^3.2.4
   vue-tsc: ^2.2.12
-  zod: ^3.25.76
+  zod: ^4.3.6


### PR DESCRIPTION
Supports zod 4

With vee-validate's support for [`standardschema`](https://standardschema.dev/), validator integration packages are no longer required, so `@vee-validate/zod` has been removed.

vee-validate migration guide:
https://vee-validate.logaretm.com/v5/guide/migration/

vee-validate 5 is still in beta, so that should be considered before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified form validation schema construction across Vue examples for improved compatibility and clarity.

* **Dependencies**
  * Upgraded validation integration and Zod to newer versions; removed unused validation packages from docs.

* **Documentation**
  * Added a top-note recommending installation of a validation library and updated API reference links to the newer release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->