### PR TITLE
feat(ThemeSwitcher): configurable font size presets with slider control

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,42 @@
+# Una UI
+
+A Vue/Nuxt UI component library built on UnoCSS. Users theme their app at runtime through the ThemeSwitcher, which persists choices to a `una-settings` store.
+
+## Language
+
+### Settings
+
+**Setting**:
+A single user-configurable theming value persisted in `una-settings` and applied as a CSS custom property on the document root.
+
+**Aesthetic Setting**:
+A Setting that changes visual style without affecting readability or scale — Primary Color, Gray Color, Radius. These are the only Settings included in Shuffle.
+_Avoid_: style setting, theme setting
+
+**Comfort Setting**:
+A Setting tied to readability or accessibility that reflects a deliberate user choice — Font Size. Never randomized by Shuffle, because a surprise change would undo the user's intent.
+_Avoid_: accessibility setting, a11y setting
+
+**Preset**:
+A labeled choice offered for a Setting (e.g. "Larger" → 18 for Font Size). Presets are app configuration, not user state — they are never persisted with Settings.
+_Avoid_: option, step, tier
+
+### Values
+
+**Font Size**:
+The root `html` font-size in pixels (`--una-font-size`). Because component dimensions are expressed in `rem`, changing it rescales the entire UI, not just text. A Comfort Setting.
+_Avoid_: text size, scale, zoom
+
+**Radius**:
+The base corner radius in rem (`--una-radius`). An Aesthetic Setting.
+
+**Primary Color** / **Gray Color**:
+The named theme palettes driving `--una-primary-*` / `--una-gray-*` custom properties. Aesthetic Settings.
+
+### Actions
+
+**Shuffle**:
+Randomizes every Aesthetic Setting at once (Primary Color, Gray Color, Radius). Deliberately excludes Comfort Settings.
+
+**Reset**:
+Restores all Settings — Aesthetic and Comfort — to their configured defaults.

--- a/docs/content/2.api/1.configuration/2.nuxt-config.md
+++ b/docs/content/2.api/1.configuration/2.nuxt-config.md
@@ -47,18 +47,19 @@ In your `app.config.ts` file, you can customize your default theme colors of Una
 You can use any color palette you want. Una UI uses [Tailwind CSS Colors](https://tailwindcss.com/docs/customizing-colors) under the hood, But you can also define your own custom theme colors, see [Extending Section](#overriding-and-extending).
 ::
 
-| Option                     | Default         | Type     | Description                        |
-| -------------------------- | --------------- | -------- | ---------------------------------- |
-| `primary`                  | `yellow`        | `string` | Primary color                      |
-| `gray`                     | `stone`         | `string` | Gray color                         |
-| `radius`                   | `0.5`           | `number` | Border radius                      |
-| `fontSize`                 | `16`            | `number` | Font size                          |
-| `sidebar.cookieName`       | `sidebar:state` | `string` | Cookie name for persisting state   |
-| `sidebar.cookieMaxAge`     | `604800`        | `number` | Cookie max age in seconds (7 days) |
-| `sidebar.width`            | `16rem`         | `string` | Sidebar width                      |
-| `sidebar.widthMobile`      | `18rem`         | `string` | Sidebar width on mobile            |
-| `sidebar.widthIcon`        | `3rem`          | `string` | Sidebar width when collapsed       |
-| `sidebar.keyboardShortcut` | `b`             | `string` | Toggle shortcut key (with ⌘/Ctrl)  |
+| Option                     | Default         | Type                                 | Description                                                                  |
+| -------------------------- | --------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
+| `primary`                  | `yellow`        | `string`                             | Primary color                                                                |
+| `gray`                     | `stone`         | `string`                             | Gray color                                                                   |
+| `radius`                   | `0.5`           | `number`                             | Border radius                                                                |
+| `fontSize`                 | `16`            | `number`                             | Root font size in px                                                         |
+| `fontSizes`                | see below       | `{ label: string, value: number }[]` | Font size presets offered by the theme switcher (replaces defaults when set) |
+| `sidebar.cookieName`       | `sidebar:state` | `string`                             | Cookie name for persisting state                                             |
+| `sidebar.cookieMaxAge`     | `604800`        | `number`                             | Cookie max age in seconds (7 days)                                           |
+| `sidebar.width`            | `16rem`         | `string`                             | Sidebar width                                                                |
+| `sidebar.widthMobile`      | `18rem`         | `string`                             | Sidebar width on mobile                                                      |
+| `sidebar.widthIcon`        | `3rem`          | `string`                             | Sidebar width when collapsed                                                 |
+| `sidebar.keyboardShortcut` | `b`             | `string`                             | Toggle shortcut key (with ⌘/Ctrl)                                            |
 
 ```ts{}[app.config.ts]
 export default defineAppConfig({
@@ -67,6 +68,13 @@ export default defineAppConfig({
     gray: 'stone',
     radius: 0.5,
     fontSize: 16,
+    fontSizes: [
+      { label: 'Smaller', value: 14 },
+      { label: 'Small', value: 15 },
+      { label: 'Default', value: 16 },
+      { label: 'Large', value: 17 },
+      { label: 'Larger', value: 18 },
+    ],
     sidebar: {
       keyboardShortcut: '.',
       width: '20rem',

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,4 +1,4 @@
-import type { UnaSettings } from './runtime/types'
+import type { UnaConfig } from './runtime/types'
 import { addComponentsDir, addImportsDir, addPlugin, createResolver, defineNuxtModule, installModule } from '@nuxt/kit'
 import { defu } from 'defu'
 import { name, version } from '../package.json'
@@ -8,10 +8,10 @@ export type * from './runtime/types'
 
 declare module '@nuxt/schema' {
   interface AppConfigInput {
-    una?: Partial<Omit<UnaSettings, 'primaryColors' | 'grayColors'>>
+    una?: Partial<UnaConfig>
   }
   interface AppConfig {
-    una: Omit<UnaSettings, 'primaryColors' | 'grayColors'>
+    una: UnaConfig
   }
 }
 
@@ -67,13 +67,21 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.alias['#una'] = resolve('./runtime')
 
+    const userUna = nuxt.options.appConfig.una || {}
     nuxt.options.appConfig.una = defu(
-      nuxt.options.appConfig.una || {},
+      userUna,
       {
         primary: 'yellow',
         gray: 'stone',
         radius: 0.5,
         fontSize: 16,
+        fontSizes: [
+          { label: 'Smaller', value: 14 },
+          { label: 'Small', value: 15 },
+          { label: 'Default', value: 16 },
+          { label: 'Large', value: 17 },
+          { label: 'Larger', value: 18 },
+        ],
         sidebar: {
           cookieName: 'sidebar:state',
           cookieMaxAge: 60 * 60 * 24 * 7,
@@ -82,8 +90,11 @@ export default defineNuxtModule<ModuleOptions>({
           widthIcon: '3rem',
           keyboardShortcut: 'b',
         },
-      } satisfies Omit<UnaSettings, 'primaryColors' | 'grayColors'>,
+      } satisfies UnaConfig,
     )
+    // defu concatenates arrays; a user-provided preset list must replace the default, not extend it
+    if (userUna.fontSizes)
+      nuxt.options.appConfig.una.fontSizes = userUna.fontSizes
 
     // Isolate root node from portaled components
     nuxt.options.app.rootAttrs = nuxt.options.app.rootAttrs || {}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -67,21 +67,17 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.alias['#una'] = resolve('./runtime')
 
-    const userUna = nuxt.options.appConfig.una || {}
+    // `fontSizes` presets are intentionally omitted from these defaults: defu (and the
+    // app.config.ts merge via defuFn) concatenates arrays, so a baked-in default would be
+    // appended to — never replaced by — a user list. The ThemeSwitcher falls back to
+    // DEFAULT_FONT_SIZE_PRESETS when `una.fontSizes` is unset, keeping user overrides clean.
     nuxt.options.appConfig.una = defu(
-      userUna,
+      nuxt.options.appConfig.una || {},
       {
         primary: 'yellow',
         gray: 'stone',
         radius: 0.5,
         fontSize: 16,
-        fontSizes: [
-          { label: 'Smaller', value: 14 },
-          { label: 'Small', value: 15 },
-          { label: 'Default', value: 16 },
-          { label: 'Large', value: 17 },
-          { label: 'Larger', value: 18 },
-        ],
         sidebar: {
           cookieName: 'sidebar:state',
           cookieMaxAge: 60 * 60 * 24 * 7,
@@ -92,9 +88,6 @@ export default defineNuxtModule<ModuleOptions>({
         },
       } satisfies UnaConfig,
     )
-    // defu concatenates arrays; a user-provided preset list must replace the default, not extend it
-    if (userUna.fontSizes)
-      nuxt.options.appConfig.una.fontSizes = userUna.fontSizes
 
     // Isolate root node from portaled components
     nuxt.options.app.rootAttrs = nuxt.options.app.rootAttrs || {}

--- a/packages/nuxt/src/runtime/components/misc/ThemeSwitcher.vue
+++ b/packages/nuxt/src/runtime/components/misc/ThemeSwitcher.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { useColorMode } from '#imports'
+import { useAppConfig, useColorMode } from '#imports'
 import { useToggle } from '@vueuse/core'
+import { SliderRange, SliderThumb, SliderTrack } from 'reka-ui'
 import { capitalize, computed } from 'vue'
 import { useUnaSettings } from '../../composables/useUnaSettings'
 import { useUnaThemes } from '../../composables/useUnaThemes'
@@ -9,8 +10,10 @@ import Button from '../elements/Button.vue'
 import Label from '../elements/Label.vue'
 import Popover from '../elements/popover/Popover.vue'
 import Separator from '../elements/Separator.vue'
+import Slider from '../forms/Slider.vue'
 
 const colorMode = useColorMode()
+const { una } = useAppConfig()
 
 const [value, toggle] = useToggle()
 const { primaryThemes, grayThemes } = useUnaThemes()
@@ -35,6 +38,52 @@ function updatePrimaryTheme(theme: string): void {
 function updateGrayTheme(theme: string): void {
   settings.value.gray = theme
 }
+
+// custom values (e.g. set via app.config) snap the thumb to the closest stop
+function closestIndex(values: readonly number[], target: number): number {
+  let closest = 0
+  values.forEach((value, index) => {
+    const best = values[closest]
+    if (best !== undefined && Math.abs(value - target) < Math.abs(best - target))
+      closest = index
+  })
+  return closest
+}
+
+const fontSizePresets = computed(() => una.fontSizes ?? [])
+
+// slider stops are preset indexes, so unevenly spaced preset values still sit evenly on the track
+const fontSizeIndex = computed<number[]>({
+  get: () => {
+    const presets = fontSizePresets.value
+    const exact = presets.findIndex(preset => preset.value === settings.value.fontSize)
+    return [exact !== -1 ? exact : closestIndex(presets.map(preset => preset.value), settings.value.fontSize)]
+  },
+  set: (value) => {
+    const preset = fontSizePresets.value[value[0] ?? 0]
+    if (preset)
+      settings.value.fontSize = preset.value
+  },
+})
+
+const currentFontSizeLabel = computed(() => {
+  const preset = fontSizePresets.value.find(preset => preset.value === settings.value.fontSize)
+  return preset ? preset.label : `${settings.value.fontSize}px`
+})
+
+const radiusIndex = computed<number[]>({
+  get: () => {
+    const exact = RADIUS.findIndex(radius => radius === settings.value.radius)
+    return [exact !== -1 ? exact : closestIndex(RADIUS, settings.value.radius)]
+  },
+  set: (value) => {
+    const radius = RADIUS[value[0] ?? 0]
+    if (radius !== undefined)
+      settings.value.radius = radius
+  },
+})
+
+const currentRadiusLabel = computed(() => `${settings.value.radius}`)
 
 function shuffleTheme(): void {
   if (primaryThemes.length > 0 && grayThemes.length > 0 && RADIUS.length > 0) {
@@ -141,24 +190,64 @@ function shuffleTheme(): void {
         <Separator />
 
         <div class="space-y-1">
-          <Label for="radius" class="text-xs"> Radius </Label>
-          <div class="grid grid-cols-3 gap-2 py-1.5">
-            <Button
-              v-for="r in RADIUS"
-              :key="r"
-              btn="solid-gray"
-              size="xs"
-              :class="
-                r === settings.radius
-                  ? 'ring-2 ring-primary'
-                  : ''
-              "
-              @click="settings.radius = r"
+          <div class="flex items-center justify-between">
+            <Label for="radius" class="text-xs"> Radius </Label>
+            <span class="text-xs text-muted">{{ currentRadiusLabel }}</span>
+          </div>
+          <div class="px-1 py-2.5">
+            <Slider
+              v-model="radiusIndex"
+              :min="0"
+              :max="RADIUS.length - 1"
+              :step="1"
+              aria-label="Radius"
             >
-              {{ r }}
-            </Button>
+              <template #slider-track>
+                <SliderTrack class="slider-track">
+                  <SliderRange class="slider-range" />
+                  <div class="pointer-events-none absolute inset-0 flex items-center justify-between px-2">
+                    <span v-for="(_, i) in RADIUS" :key="i" class="rounded-full bg-base size-1" />
+                  </div>
+                </SliderTrack>
+              </template>
+              <template #slider-thumb>
+                <SliderThumb class="slider-thumb" :aria-valuetext="currentRadiusLabel" />
+              </template>
+            </Slider>
           </div>
         </div>
+
+        <template v-if="fontSizePresets.length">
+          <Separator />
+
+          <div class="space-y-1">
+            <div class="flex items-center justify-between">
+              <Label for="font-size" class="text-xs"> Font Size </Label>
+              <span class="text-xs text-muted">{{ currentFontSizeLabel }}</span>
+            </div>
+            <div class="px-1 py-2.5">
+              <Slider
+                v-model="fontSizeIndex"
+                :min="0"
+                :max="fontSizePresets.length - 1"
+                :step="1"
+                aria-label="Font Size"
+              >
+                <template #slider-track>
+                  <SliderTrack class="slider-track">
+                    <SliderRange class="slider-range" />
+                    <div class="pointer-events-none absolute inset-0 flex items-center justify-between px-2">
+                      <span v-for="(_, i) in fontSizePresets" :key="i" class="rounded-full bg-base size-1" />
+                    </div>
+                  </SliderTrack>
+                </template>
+                <template #slider-thumb>
+                  <SliderThumb class="slider-thumb" :aria-valuetext="currentFontSizeLabel" />
+                </template>
+              </Slider>
+            </div>
+          </div>
+        </template>
 
         <Separator />
 

--- a/packages/nuxt/src/runtime/components/misc/ThemeSwitcher.vue
+++ b/packages/nuxt/src/runtime/components/misc/ThemeSwitcher.vue
@@ -5,7 +5,7 @@ import { SliderRange, SliderThumb, SliderTrack } from 'reka-ui'
 import { capitalize, computed } from 'vue'
 import { useUnaSettings } from '../../composables/useUnaSettings'
 import { useUnaThemes } from '../../composables/useUnaThemes'
-import { RADIUS } from '../../constants'
+import { DEFAULT_FONT_SIZE_PRESETS, RADIUS } from '../../constants'
 import Button from '../elements/Button.vue'
 import Label from '../elements/Label.vue'
 import Popover from '../elements/popover/Popover.vue'
@@ -50,7 +50,7 @@ function closestIndex(values: readonly number[], target: number): number {
   return closest
 }
 
-const fontSizePresets = computed(() => una.fontSizes ?? [])
+const fontSizePresets = computed(() => una.fontSizes ?? DEFAULT_FONT_SIZE_PRESETS)
 
 // slider stops are preset indexes, so unevenly spaced preset values still sit evenly on the track
 const fontSizeIndex = computed<number[]>({
@@ -191,7 +191,7 @@ function shuffleTheme(): void {
 
         <div class="space-y-1">
           <div class="flex items-center justify-between">
-            <Label for="radius" class="text-xs"> Radius </Label>
+            <Label class="text-xs"> Radius </Label>
             <span class="text-xs text-muted">{{ currentRadiusLabel }}</span>
           </div>
           <div class="px-1 py-2.5">
@@ -217,12 +217,12 @@ function shuffleTheme(): void {
           </div>
         </div>
 
-        <template v-if="fontSizePresets.length">
+        <template v-if="fontSizePresets.length > 1">
           <Separator />
 
           <div class="space-y-1">
             <div class="flex items-center justify-between">
-              <Label for="font-size" class="text-xs"> Font Size </Label>
+              <Label class="text-xs"> Font Size </Label>
               <span class="text-xs text-muted">{{ currentFontSizeLabel }}</span>
             </div>
             <div class="px-1 py-2.5">

--- a/packages/nuxt/src/runtime/constants.ts
+++ b/packages/nuxt/src/runtime/constants.ts
@@ -1,1 +1,11 @@
+import type { UnaFontSizePreset } from './types'
+
 export const RADIUS = [0, 0.25, 0.375, 0.5, 0.625, 0.75, 1] as const
+
+export const DEFAULT_FONT_SIZE_PRESETS: UnaFontSizePreset[] = [
+  { label: 'Smaller', value: 14 },
+  { label: 'Small', value: 15 },
+  { label: 'Default', value: 16 },
+  { label: 'Large', value: 17 },
+  { label: 'Larger', value: 18 },
+]

--- a/packages/nuxt/src/runtime/types/index.ts
+++ b/packages/nuxt/src/runtime/types/index.ts
@@ -90,7 +90,8 @@ export interface UnaFontSizePreset {
 }
 
 export interface UnaConfig extends Omit<UnaSettings, 'primaryColors' | 'grayColors'> {
-  fontSizes: UnaFontSizePreset[]
+  /** Font size presets offered by the theme switcher. Falls back to DEFAULT_FONT_SIZE_PRESETS when unset. */
+  fontSizes?: UnaFontSizePreset[]
 }
 
 export type OutsideEvent<T extends Event> = CustomEvent<{

--- a/packages/nuxt/src/runtime/types/index.ts
+++ b/packages/nuxt/src/runtime/types/index.ts
@@ -84,6 +84,15 @@ export interface UnaSettings {
   sidebar: UnaSidebarConfig
 }
 
+export interface UnaFontSizePreset {
+  label: string
+  value: number
+}
+
+export interface UnaConfig extends Omit<UnaSettings, 'primaryColors' | 'grayColors'> {
+  fontSizes: UnaFontSizePreset[]
+}
+
 export type OutsideEvent<T extends Event> = CustomEvent<{
   originalEvent: T
 }>


### PR DESCRIPTION
## Summary

- Add `una.fontSizes` app config: `{ label: string, value: number }[]` presets (default Smaller 14 → Larger 18) that drive a new Font Size control in the ThemeSwitcher
- A user-provided preset list **replaces** the defaults (guard against defu array concatenation); presets are config, not user state — only the chosen `fontSize` number persists, so existing `una-settings` storage keeps working unchanged
- ThemeSwitcher renders presets as a discrete slider: one evenly spaced stop per preset (uneven values like 12/14/16/20 still space evenly), tick dots on the track, active preset label readback beside the section title; off-preset values show as raw px with the thumb snapped to the closest stop; empty list hides the section
- Radius section adopts the same slider + readback idiom (was a 3-row button grid), sharing one interaction pattern and shrinking the popover
- Screen readers announce the human label ("Default", "0.625") via `aria-valuetext` instead of the internal stop index
- Shuffle continues to exclude font size — it randomizes aesthetic settings only (colors, radius)
- Docs: `fontSizes` row + example in Nuxt config; new root `CONTEXT.md` glossary capturing the Setting/Preset and Aesthetic/Comfort vocabulary

Closes #584

## Test plan

- [ ] `pnpm typecheck` and `pnpm lint` pass (verified locally)
- [ ] Open ThemeSwitcher → Font Size slider shows 5 stops with ticks; dragging updates root font size live and persists across reload
- [ ] Radius slider mirrors the same behavior; Shuffle randomizes colors + radius only; Reset restores defaults
- [ ] Configure custom `una.fontSizes` in `app.config.ts` → slider stop count/labels follow the list exactly (no merged ghosts)
- [ ] VoiceOver/NVDA announce preset labels on the slider thumbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable font-size presets to theme settings (including root font size support).
  * Improved the theme “Customize” UI: radius selection is now a slider with preset snapping and accessible value labels.
  * Added a font-size slider with preset tick markers, shown when multiple presets are available.

* **Documentation**
  * Added/updated documentation for Una UI theming, including settings concepts, presets, and shuffle/reset behavior.
  * Expanded Nuxt configuration docs to document the new `fontSizes` theme option and related defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->