### PR TITLE
fix: AvatarGroup size cascade and icon-only square across all Button wrappers

### DIFF
--- a/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogAction.vue
+++ b/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogAction.vue
@@ -6,7 +6,6 @@ import Button from '../elements/Button.vue'
 const props = withDefaults(defineProps<NAlertDialogActionProps>(), {
   btn: 'solid-primary',
   label: 'Continue',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 </script>

--- a/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogAction.vue
+++ b/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogAction.vue
@@ -6,6 +6,8 @@ import Button from '../elements/Button.vue'
 const props = withDefaults(defineProps<NAlertDialogActionProps>(), {
   btn: 'solid-primary',
   label: 'Continue',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 </script>
 

--- a/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogCancel.vue
+++ b/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogCancel.vue
@@ -7,7 +7,6 @@ import Button from '../elements/Button.vue'
 const props = withDefaults(defineProps<NAlertDialogCancelProps>(), {
   btn: 'solid-gray',
   label: 'Cancel',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 </script>

--- a/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogCancel.vue
+++ b/packages/nuxt/src/runtime/components/alert-dialog/AlertDialogCancel.vue
@@ -7,6 +7,8 @@ import Button from '../elements/Button.vue'
 const props = withDefaults(defineProps<NAlertDialogCancelProps>(), {
   btn: 'solid-gray',
   label: 'Cancel',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 </script>
 

--- a/packages/nuxt/src/runtime/components/combobox/ComboboxTrigger.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxTrigger.vue
@@ -9,6 +9,8 @@ import Icon from '../elements/Icon.vue'
 
 const props = withDefaults(defineProps<NComboboxTriggerProps>(), {
   btn: 'solid-white',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 
 const forwardedProps = useForwardProps(reactiveOmit(props, 'class', 'status', 'una', 'btn'))

--- a/packages/nuxt/src/runtime/components/combobox/ComboboxTrigger.vue
+++ b/packages/nuxt/src/runtime/components/combobox/ComboboxTrigger.vue
@@ -9,7 +9,6 @@ import Icon from '../elements/Icon.vue'
 
 const props = withDefaults(defineProps<NComboboxTriggerProps>(), {
   btn: 'solid-white',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 

--- a/packages/nuxt/src/runtime/components/drawer/DrawerClose.vue
+++ b/packages/nuxt/src/runtime/components/drawer/DrawerClose.vue
@@ -2,7 +2,9 @@
 import type { NDrawerCloseProps } from '../../types'
 import { DrawerClose } from 'vaul-vue'
 
-const props = defineProps<NDrawerCloseProps>()
+const props = withDefaults(defineProps<NDrawerCloseProps>(), {
+  square: undefined,
+})
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/elements/AvatarGroup.vue
+++ b/packages/nuxt/src/runtime/components/elements/AvatarGroup.vue
@@ -9,10 +9,7 @@ import Avatar from './avatar/Avatar.vue'
 
 const props = withDefaults(defineProps<NAvatarGroupProps>(), {
   as: 'div',
-  size: undefined,
   square: undefined,
-  rounded: undefined,
-  avatar: undefined,
 })
 
 const slots = defineSlots()
@@ -65,15 +62,17 @@ const visibleAvatars = computed(() => {
 
 const rootProps = reactiveOmit(props, ['max', 'as', 'asChild', 'overflowLabel', 'class', 'size'])
 
-function forwardedRootProps() {
-  return Object.fromEntries(
+// Only the group's explicitly-set style props cascade to children; unset/false
+// booleans (square, icon) are dropped so children keep their own defaults.
+const forwardedProps = computed(() =>
+  Object.fromEntries(
     Object.entries(rootProps).filter(([, value]) => value !== undefined && value !== false),
-  )
-}
+  ),
+)
 
 const displayAvatars = computed(() => {
   const result = [...visibleAvatars.value]
-  const groupProps = forwardedRootProps()
+  const groupProps = forwardedProps.value
 
   if (hiddenCount.value > 0 || props.overflowLabel) {
     const avatarProps = children.value.length > 0
@@ -104,18 +103,19 @@ const displayAvatars = computed(() => {
 })
 
 const clonedAvatars = computed(() => {
-  const groupProps = forwardedRootProps()
+  const groupProps = forwardedProps.value
 
-  return displayAvatars.value.map((avatar: VNode, count: number) => {
+  return displayAvatars.value.map((avatar: VNode) => {
+    const ownProps = avatar.props || {}
+    // Cascade group props only where the child hasn't set its own. cloneVNode already
+    // merges `ownProps`, so re-spreading them would duplicate the child's class tokens.
+    const inherited = Object.fromEntries(
+      Object.entries(groupProps).filter(([key]) => !(key in ownProps)),
+    )
+
     const cloned = cloneVNode(avatar, {
-      ...groupProps,
-      ...avatar.props,
-      class: cn(
-        'avatar-group-item',
-        avatar.props?.class,
-        props.class,
-      ),
-      key: count,
+      ...inherited,
+      class: cn('avatar-group-item', props.class),
     })
 
     if (avatar.ref)

--- a/packages/nuxt/src/runtime/components/elements/AvatarGroup.vue
+++ b/packages/nuxt/src/runtime/components/elements/AvatarGroup.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
+import type { VNode } from 'vue'
 import type { NAvatarGroupProps } from '../../types'
 import { reactiveOmit } from '@vueuse/core'
 import { Primitive } from 'reka-ui'
-import { computed, h } from 'vue'
+import { cloneVNode, computed, h } from 'vue'
 import { cn, omitProps } from '../../utils'
 import Avatar from './avatar/Avatar.vue'
 
 const props = withDefaults(defineProps<NAvatarGroupProps>(), {
   as: 'div',
+  // Keep unset so Boolean-cast props don't forward `false` and wipe Avatar defaults.
+  size: undefined,
+  square: undefined,
+  rounded: undefined,
+  avatar: undefined,
 })
 
 const slots = defineSlots()
@@ -58,16 +64,29 @@ const visibleAvatars = computed(() => {
   return [...children.value].slice(0, maxVisibleCount.value).reverse()
 })
 
+// `size` stays on the group root so children inherit font-size via CSS.
+const rootProps = reactiveOmit(props, ['max', 'as', 'asChild', 'overflowLabel', 'class', 'size'])
+
+/** Only forward props that were actually set on the group (skip unset Boolean casts). */
+function forwardedRootProps() {
+  return Object.fromEntries(
+    Object.entries(rootProps).filter(([, value]) => value !== undefined && value !== false),
+  )
+}
+
 const displayAvatars = computed(() => {
   const result = [...visibleAvatars.value]
+  const groupProps = forwardedRootProps()
 
   if (hiddenCount.value > 0 || props.overflowLabel) {
     const avatarProps = children.value.length > 0
-      ? omitProps(children.value[0].props || {}, ['src', 'alt', 'label', 'icon'])
+      ? omitProps(children.value[0].props || {}, ['src', 'alt', 'label', 'icon', 'size'])
       : {}
 
     result.unshift(
       h(Avatar, {
+        ...groupProps,
+        ...avatarProps,
         label: props.overflowLabel || `+${hiddenCount.value}`,
         class: cn(
           props.una?.avatarGroupCount,
@@ -80,7 +99,6 @@ const displayAvatars = computed(() => {
           ),
           ...avatarProps.una,
         },
-        ...avatarProps,
       }),
     )
   }
@@ -88,7 +106,29 @@ const displayAvatars = computed(() => {
   return result
 })
 
-const rootProps = reactiveOmit(props, ['max', 'as', 'asChild', 'overflowLabel'])
+const clonedAvatars = computed(() => {
+  const groupProps = forwardedRootProps()
+
+  return displayAvatars.value.map((avatar: VNode, count: number) => {
+    // Do not forward group `size` — it stays on the root and cascades via size-inherit.
+    // A child may still set its own `size` through avatar.props.
+    const cloned = cloneVNode(avatar, {
+      ...groupProps,
+      ...avatar.props,
+      class: cn(
+        'avatar-group-item',
+        avatar.props?.class,
+        props.class,
+      ),
+      key: count,
+    })
+
+    if (avatar.ref)
+      cloned.ref = avatar.ref
+
+    return cloned
+  })
+})
 </script>
 
 <template>
@@ -103,13 +143,8 @@ const rootProps = reactiveOmit(props, ['max', 'as', 'asChild', 'overflowLabel'])
   >
     <component
       :is="avatar"
-      v-for="(avatar, count) in displayAvatars"
-      v-bind="{ ...rootProps, ...avatar.props }"
+      v-for="(avatar, count) in clonedAvatars"
       :key="count"
-      :class="cn(
-        'avatar-group-item',
-        props.class,
-      )"
     />
   </Primitive>
 </template>

--- a/packages/nuxt/src/runtime/components/elements/AvatarGroup.vue
+++ b/packages/nuxt/src/runtime/components/elements/AvatarGroup.vue
@@ -9,7 +9,6 @@ import Avatar from './avatar/Avatar.vue'
 
 const props = withDefaults(defineProps<NAvatarGroupProps>(), {
   as: 'div',
-  // Keep unset so Boolean-cast props don't forward `false` and wipe Avatar defaults.
   size: undefined,
   square: undefined,
   rounded: undefined,
@@ -64,10 +63,8 @@ const visibleAvatars = computed(() => {
   return [...children.value].slice(0, maxVisibleCount.value).reverse()
 })
 
-// `size` stays on the group root so children inherit font-size via CSS.
 const rootProps = reactiveOmit(props, ['max', 'as', 'asChild', 'overflowLabel', 'class', 'size'])
 
-/** Only forward props that were actually set on the group (skip unset Boolean casts). */
 function forwardedRootProps() {
   return Object.fromEntries(
     Object.entries(rootProps).filter(([, value]) => value !== undefined && value !== false),
@@ -110,8 +107,6 @@ const clonedAvatars = computed(() => {
   const groupProps = forwardedRootProps()
 
   return displayAvatars.value.map((avatar: VNode, count: number) => {
-    // Do not forward group `size` — it stays on the root and cascades via size-inherit.
-    // A child may still set its own `size` through avatar.props.
     const cloned = cloneVNode(avatar, {
       ...groupProps,
       ...avatar.props,

--- a/packages/nuxt/src/runtime/components/elements/Button.vue
+++ b/packages/nuxt/src/runtime/components/elements/Button.vue
@@ -11,7 +11,6 @@ const props = withDefaults(defineProps<NButtonProps>(), {
   size: 'sm',
   rounded: 'md',
   loadingPlacement: 'leading',
-  // Preserve unset so `square ?? !!icon` can auto-enable; Vue Boolean props default to false.
   square: undefined,
   una: () => ({
     btnDefaultVariant: 'btn-default-variant',

--- a/packages/nuxt/src/runtime/components/elements/Button.vue
+++ b/packages/nuxt/src/runtime/components/elements/Button.vue
@@ -11,6 +11,8 @@ const props = withDefaults(defineProps<NButtonProps>(), {
   size: 'sm',
   rounded: 'md',
   loadingPlacement: 'leading',
+  // Preserve unset so `square ?? !!icon` can auto-enable; Vue Boolean props default to false.
+  square: undefined,
   una: () => ({
     btnDefaultVariant: 'btn-default-variant',
   }),

--- a/packages/nuxt/src/runtime/components/elements/accordion/AccordionTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/accordion/AccordionTrigger.vue
@@ -7,6 +7,8 @@ import { cn } from '../../../utils'
 const props = withDefaults(defineProps<NAccordionTriggerProps>(), {
   btn: '~ text',
   trailing: 'accordion-trailing-icon',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 const forwardProps = useForwardProps(reactiveOmit(props, ['una']))
 </script>

--- a/packages/nuxt/src/runtime/components/elements/accordion/AccordionTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/accordion/AccordionTrigger.vue
@@ -7,7 +7,6 @@ import { cn } from '../../../utils'
 const props = withDefaults(defineProps<NAccordionTriggerProps>(), {
   btn: '~ text',
   trailing: 'accordion-trailing-icon',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 const forwardProps = useForwardProps(reactiveOmit(props, ['una']))

--- a/packages/nuxt/src/runtime/components/elements/avatar/Avatar.vue
+++ b/packages/nuxt/src/runtime/components/elements/avatar/Avatar.vue
@@ -11,8 +11,6 @@ defineOptions({
 
 const props = withDefaults(defineProps<NAvatarProps>(), {
   as: 'span',
-  // Leave unset so AvatarGroup `size` can cascade via CSS (size-inherit on items).
-  // Standalone default comes from the `avatar` preset (`text-md`).
   size: undefined,
   rounded: 'full',
   square: '2.5em',

--- a/packages/nuxt/src/runtime/components/elements/avatar/Avatar.vue
+++ b/packages/nuxt/src/runtime/components/elements/avatar/Avatar.vue
@@ -11,7 +11,9 @@ defineOptions({
 
 const props = withDefaults(defineProps<NAvatarProps>(), {
   as: 'span',
-  size: 'md',
+  // Leave unset so AvatarGroup `size` can cascade via CSS (size-inherit on items).
+  // Standalone default comes from the `avatar` preset (`text-md`).
+  size: undefined,
   rounded: 'full',
   square: '2.5em',
   avatar: 'soft',
@@ -25,7 +27,7 @@ const props = withDefaults(defineProps<NAvatarProps>(), {
       una?.avatarRoot,
       props.class,
     )"
-    :size
+    :size="size || undefined"
     :rounded
     :square
     :avatar

--- a/packages/nuxt/src/runtime/components/elements/avatar/AvatarFallback.vue
+++ b/packages/nuxt/src/runtime/components/elements/avatar/AvatarFallback.vue
@@ -9,7 +9,7 @@ const props = defineProps<NAvatarAvatarFallbackProps>()
 
 <template>
   <AvatarFallback
-    v-bind="omitProps(props, ['label', 'una', 'icon'])"
+    v-bind="omitProps(props, ['label', 'una', 'icon', 'square', 'size', 'rounded', 'class'])"
     :class="cn(
       'avatar-fallback',
       una?.avatarFallback,

--- a/packages/nuxt/src/runtime/components/elements/avatar/AvatarImage.vue
+++ b/packages/nuxt/src/runtime/components/elements/avatar/AvatarImage.vue
@@ -8,7 +8,7 @@ const props = defineProps<NAvatarImageProps>()
 
 <template>
   <AvatarImage
-    v-bind="omitProps(props, ['class', 'una'])"
+    v-bind="omitProps(props, ['class', 'una', 'square', 'size', 'rounded'])"
     :src="src!"
     :class="cn(
       'avatar-image',

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenu.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenu.vue
@@ -16,7 +16,6 @@ import DropdownMenuSubTrigger from './DropdownMenuSubTrigger.vue'
 import DropdownMenuTrigger from './DropdownMenuTrigger.vue'
 
 const props = withDefaults(defineProps<NDropdownMenuProps>(), {
-  // Preserve unset so DropdownMenuTrigger `square ?? !!icon` is not wiped by Boolean false.
   square: undefined,
 })
 const emits = defineEmits<DropdownMenuRootEmits & DropdownMenuContentEmits>()

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenu.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenu.vue
@@ -15,7 +15,10 @@ import DropdownMenuSubContent from './DropdownMenuSubContent.vue'
 import DropdownMenuSubTrigger from './DropdownMenuSubTrigger.vue'
 import DropdownMenuTrigger from './DropdownMenuTrigger.vue'
 
-const props = defineProps<NDropdownMenuProps>()
+const props = withDefaults(defineProps<NDropdownMenuProps>(), {
+  // Preserve unset so DropdownMenuTrigger `square ?? !!icon` is not wiped by Boolean false.
+  square: undefined,
+})
 const emits = defineEmits<DropdownMenuRootEmits & DropdownMenuContentEmits>()
 const forwarded = useForwardPropsEmits(props, emits)
 

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuItem.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuItem.vue
@@ -15,7 +15,6 @@ const props = withDefaults(defineProps<NDropdownMenuItemProps>(), {
   size: 'sm',
   dropdownMenuItem: '~',
   rounded: 'sm',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuItem.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuItem.vue
@@ -15,6 +15,8 @@ const props = withDefaults(defineProps<NDropdownMenuItemProps>(), {
   size: 'sm',
   dropdownMenuItem: '~',
   rounded: 'sm',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 
 const slots = defineSlots<any>()

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSubTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSubTrigger.vue
@@ -12,7 +12,6 @@ import Button from '../Button.vue'
 const props = withDefaults(defineProps<NDropdownMenuSubTriggerProps>(), {
   dropdownMenuItem: '~',
   rounded: 'sm',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 const delegatedProps = reactiveOmit(props, ['class'])

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSubTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuSubTrigger.vue
@@ -12,6 +12,8 @@ import Button from '../Button.vue'
 const props = withDefaults(defineProps<NDropdownMenuSubTriggerProps>(), {
   dropdownMenuItem: '~',
   rounded: 'sm',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 const delegatedProps = reactiveOmit(props, ['class'])
 

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuTrigger.vue
@@ -4,7 +4,10 @@ import { DropdownMenuTrigger, useForwardProps } from 'reka-ui'
 import { cn, randomId } from '../../../utils'
 import Button from '../Button.vue'
 
-const props = defineProps<NDropdownMenuTriggerProps>()
+const props = withDefaults(defineProps<NDropdownMenuTriggerProps>(), {
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
+})
 
 const forwardedProps = useForwardProps(props)
 </script>

--- a/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/dropdown-menu/DropdownMenuTrigger.vue
@@ -5,7 +5,6 @@ import { cn, randomId } from '../../../utils'
 import Button from '../Button.vue'
 
 const props = withDefaults(defineProps<NDropdownMenuTriggerProps>(), {
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 

--- a/packages/nuxt/src/runtime/components/elements/pagination/Pagination.vue
+++ b/packages/nuxt/src/runtime/components/elements/pagination/Pagination.vue
@@ -17,7 +17,6 @@ const props = withDefaults(defineProps<NPaginationProps>(), {
   showListItem: true,
   showNext: true,
   showPrev: true,
-  // Preserve unset so child defaults (`square: true`) are not wiped by Boolean false.
   square: undefined,
 })
 

--- a/packages/nuxt/src/runtime/components/elements/pagination/Pagination.vue
+++ b/packages/nuxt/src/runtime/components/elements/pagination/Pagination.vue
@@ -17,6 +17,8 @@ const props = withDefaults(defineProps<NPaginationProps>(), {
   showListItem: true,
   showNext: true,
   showPrev: true,
+  // Preserve unset so child defaults (`square: true`) are not wiped by Boolean false.
+  square: undefined,
 })
 
 const emits = defineEmits<PaginationRootEmits>()

--- a/packages/nuxt/src/runtime/components/elements/tabs/TabsTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/tabs/TabsTrigger.vue
@@ -8,6 +8,8 @@ import Button from '../Button.vue'
 const props = withDefaults(defineProps<NTabsTriggerProps>(), {
   tabsActive: 'soft-black',
   size: 'sm',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 
 const delegatedProps = reactiveOmit(props, ['class', 'size'])

--- a/packages/nuxt/src/runtime/components/elements/tabs/TabsTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/tabs/TabsTrigger.vue
@@ -8,7 +8,6 @@ import Button from '../Button.vue'
 const props = withDefaults(defineProps<NTabsTriggerProps>(), {
   tabsActive: 'soft-black',
   size: 'sm',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 

--- a/packages/nuxt/src/runtime/components/elements/tooltip/TooltipTrigger.vue
+++ b/packages/nuxt/src/runtime/components/elements/tooltip/TooltipTrigger.vue
@@ -2,7 +2,9 @@
 import type { NTooltipTriggerProps } from '../../../types'
 import { TooltipTrigger } from 'reka-ui'
 
-const props = defineProps<NTooltipTriggerProps>()
+const props = withDefaults(defineProps<NTooltipTriggerProps>(), {
+  square: undefined,
+})
 </script>
 
 <template>

--- a/packages/nuxt/src/runtime/components/forms/select/SelectTrigger.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectTrigger.vue
@@ -9,7 +9,6 @@ import Icon from '../../elements/Icon.vue'
 
 const props = withDefaults(defineProps<NSelectTriggerProps>(), {
   select: 'solid-white',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 

--- a/packages/nuxt/src/runtime/components/forms/select/SelectTrigger.vue
+++ b/packages/nuxt/src/runtime/components/forms/select/SelectTrigger.vue
@@ -9,6 +9,8 @@ import Icon from '../../elements/Icon.vue'
 
 const props = withDefaults(defineProps<NSelectTriggerProps>(), {
   select: 'solid-white',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 
 const forwardedProps = useForwardProps(reactiveOmit(props, 'class', 'status', 'una', 'select'))

--- a/packages/nuxt/src/runtime/components/hover-card/HoverCardTrigger.vue
+++ b/packages/nuxt/src/runtime/components/hover-card/HoverCardTrigger.vue
@@ -4,7 +4,9 @@ import { reactiveOmit } from '@vueuse/core'
 import { HoverCardTrigger, useForwardProps } from 'reka-ui'
 import { cn } from '../../utils'
 
-const props = defineProps<NHoverCardTriggerProps>()
+const props = withDefaults(defineProps<NHoverCardTriggerProps>(), {
+  square: undefined,
+})
 const delegatedProps = reactiveOmit(props, 'class')
 
 const forwarded = useForwardProps(delegatedProps)

--- a/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuLink.vue
+++ b/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuLink.vue
@@ -13,7 +13,6 @@ const props = withDefaults(defineProps<NNavigationMenuLinkProps>(), {
   navigationMenuLink: 'ghost-white',
   btn: '~',
   as: Button,
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 const emits = defineEmits<NavigationMenuLinkEmits>()

--- a/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuLink.vue
+++ b/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuLink.vue
@@ -13,6 +13,8 @@ const props = withDefaults(defineProps<NNavigationMenuLinkProps>(), {
   navigationMenuLink: 'ghost-white',
   btn: '~',
   as: Button,
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 const emits = defineEmits<NavigationMenuLinkEmits>()
 

--- a/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuTrigger.vue
+++ b/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuTrigger.vue
@@ -17,7 +17,6 @@ const props = withDefaults(defineProps<NNavigationMenuTriggerProps>(), {
   navigationMenu: 'ghost-white',
   trailing: 'navigation-menu-trigger-trailing-icon',
   as: Button,
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 

--- a/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuTrigger.vue
+++ b/packages/nuxt/src/runtime/components/navigation-menu/NavigationMenuTrigger.vue
@@ -17,6 +17,8 @@ const props = withDefaults(defineProps<NNavigationMenuTriggerProps>(), {
   navigationMenu: 'ghost-white',
   trailing: 'navigation-menu-trigger-trailing-icon',
   as: Button,
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 
 const delegatedProps = reactiveOmit(props, 'class')

--- a/packages/nuxt/src/runtime/components/navigation/breadcrumb/BreadcrumbLink.vue
+++ b/packages/nuxt/src/runtime/components/navigation/breadcrumb/BreadcrumbLink.vue
@@ -9,6 +9,8 @@ const props = withDefaults(defineProps<NBreadcrumbLinkProps>(), {
   breadcrumbActive: '~',
   breadcrumbInactive: '~',
   size: 'sm',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 
 const activeAttrs = computed(() => {

--- a/packages/nuxt/src/runtime/components/navigation/breadcrumb/BreadcrumbLink.vue
+++ b/packages/nuxt/src/runtime/components/navigation/breadcrumb/BreadcrumbLink.vue
@@ -9,7 +9,6 @@ const props = withDefaults(defineProps<NBreadcrumbLinkProps>(), {
   breadcrumbActive: '~',
   breadcrumbInactive: '~',
   size: 'sm',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 

--- a/packages/nuxt/src/runtime/components/overlays/toast/ToastAction.vue
+++ b/packages/nuxt/src/runtime/components/overlays/toast/ToastAction.vue
@@ -13,6 +13,8 @@ defineOptions({
 const props = withDefaults(defineProps<NToastActionProps>(), {
   btn: 'solid-white',
   size: 'xs',
+  // Preserve unset so Button `square ?? !!icon` can auto-enable.
+  square: undefined,
 })
 const delegatedProps = reactiveOmit(props, ['class'])
 </script>

--- a/packages/nuxt/src/runtime/components/overlays/toast/ToastAction.vue
+++ b/packages/nuxt/src/runtime/components/overlays/toast/ToastAction.vue
@@ -13,7 +13,6 @@ defineOptions({
 const props = withDefaults(defineProps<NToastActionProps>(), {
   btn: 'solid-white',
   size: 'xs',
-  // Preserve unset so Button `square ?? !!icon` can auto-enable.
   square: undefined,
 })
 const delegatedProps = reactiveOmit(props, ['class'])

--- a/packages/preset/src/_shortcuts/avatar-group.ts
+++ b/packages/preset/src/_shortcuts/avatar-group.ts
@@ -2,7 +2,8 @@ type AvatarGroupPrefix = 'avatar-group'
 
 export const staticAvatarGroup: Record<`${AvatarGroupPrefix}-${string}` | AvatarGroupPrefix, string> = {
   'avatar-group': 'flex flex-row-reverse justify-end',
-  'avatar-group-item': 'ring-0.125em ring-background -me-0.375em first:me-0',
+  // size-inherit: scale with AvatarGroup `size` via CSS (em-based square)
+  'avatar-group-item': 'size-inherit ring-0.125em ring-background -me-0.375em first:me-0',
   'avatar-group-count': 'text-0.875em',
 }
 

--- a/packages/preset/src/_shortcuts/avatar-group.ts
+++ b/packages/preset/src/_shortcuts/avatar-group.ts
@@ -2,7 +2,6 @@ type AvatarGroupPrefix = 'avatar-group'
 
 export const staticAvatarGroup: Record<`${AvatarGroupPrefix}-${string}` | AvatarGroupPrefix, string> = {
   'avatar-group': 'flex flex-row-reverse justify-end',
-  // size-inherit: scale with AvatarGroup `size` via CSS (em-based square)
   'avatar-group-item': 'size-inherit ring-0.125em ring-background -me-0.375em first:me-0',
   'avatar-group-count': 'text-0.875em',
 }

--- a/packages/preset/src/_shortcuts/avatar.ts
+++ b/packages/preset/src/_shortcuts/avatar.ts
@@ -2,7 +2,6 @@ type AvatarPrefix = 'avatar'
 
 export const staticAvatar: Record<`${AvatarPrefix}-${string}` | AvatarPrefix, string> = {
   // base
-  // text-md = standalone default; AvatarGroup items use size-inherit to pick up group size
   'avatar': 'relative inline-flex items-center font-normal select-none shrink-0 overflow-hidden text-md',
   'avatar-image': 'h-full w-full object-cover',
   'avatar-fallback': 'flex h-full w-full items-center justify-center',

--- a/packages/preset/src/_shortcuts/avatar.ts
+++ b/packages/preset/src/_shortcuts/avatar.ts
@@ -2,7 +2,8 @@ type AvatarPrefix = 'avatar'
 
 export const staticAvatar: Record<`${AvatarPrefix}-${string}` | AvatarPrefix, string> = {
   // base
-  'avatar': 'relative inline-flex items-center font-normal select-none shrink-0 overflow-hidden',
+  // text-md = standalone default; AvatarGroup items use size-inherit to pick up group size
+  'avatar': 'relative inline-flex items-center font-normal select-none shrink-0 overflow-hidden text-md',
   'avatar-image': 'h-full w-full object-cover',
   'avatar-fallback': 'flex h-full w-full items-center justify-center',
 


### PR DESCRIPTION
## Summary
- Fixes AvatarGroup so `size` on the group scales children via CSS cascade (`size-inherit` + em-based square), with working overlap and `+N` overflow.
- Fixes icon-only Button auto-`square` by keeping unset `square` as `undefined` (Vue Boolean cast was forcing `false` and breaking `square ?? !!icon`).
- Applies the same unset-`square` default across **all** Button wrappers — Pagination, DropdownMenu, Select/Combobox, Tabs, NavMenu, AlertDialog, Toast, Accordion, Breadcrumb, **and TooltipTrigger, HoverCardTrigger, DrawerClose** (the last three extend `NButtonProps` and render `as-child`, so a leaked `square: false` killed auto-square on the slotted Button).
- Hardens AvatarGroup's `cloneVNode` cascade: stops re-spreading the child's own props (which `cloneVNode` already merges) so class tokens are no longer duplicated, drops the redundant `key`, and removes dead `size`/`rounded`/`avatar` `undefined` defaults (pure-string props are never Boolean-cast).

Closes #586

## Test plan (verified in playground on live source)
- [x] Playground `/components/avatar-group`: group `size="xl"`, children without own `size` — larger overlapping avatars + correct `+N` (root & all items compute to 20px / 50px, `+7` overflow correct)
- [x] Each avatar item's class is exactly `avatar avatar-group-item` — no duplicated tokens
- [x] Standalone Avatar still looks default-sized
- [x] Icon-only Button (`icon` + icon label, no `square`) gets square class/layout
- [x] Explicit `:square="false"` still disables auto-square
- [x] Icon-only Button inside `NTooltip` / `NHoverCard` (as-child) is square — negative control confirmed the wrapper fix is load-bearing (reverting it drops `btn-square`)
- [x] `pnpm typecheck` (vue-tsc) and `eslint` pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prop handling across interactive controls and avatar components for more consistent styling and attribute forwarding.
  * Avatar groups now preserve inherited sizing and apply avatar item classes more reliably.
  * Avatar sizing no longer defaults unexpectedly when no size is specified.
  * Avatar fallback and image elements prevent unrelated visual props from being passed through.

* **Style**
  * Updated avatar styling to improve text sizing and inherited dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
