### PR TITLE
fix(preset): use muted-foreground for muted text

### DIFF
--- a/packages/preset/src/_shortcuts/form-group.ts
+++ b/packages/preset/src/_shortcuts/form-group.ts
@@ -22,8 +22,8 @@ export const staticFormGroup: Record<`${FormGroupPrefix}-${string}` | FormGroupP
   'form-group-counter-wrapper': 'text-0.8em',
   'form-group-counter-error': 'text-error',
   'form-group-counter-current': 'text-accent-foreground',
-  'form-group-counter-separator': 'text-muted',
-  'form-group-counter-max': 'text-muted',
+  'form-group-counter-separator': 'text-muted-foreground',
+  'form-group-counter-max': 'text-muted-foreground',
 }
 
 export const formGroup = [

--- a/packages/preset/src/_shortcuts/number-field.ts
+++ b/packages/preset/src/_shortcuts/number-field.ts
@@ -5,7 +5,7 @@ export const staticNumberField: Record<`${NumberFieldPrefix}-${string}` | Number
   'number-field': 'grid gap-1.5',
   'number-field-content': 'relative [&>[data-slot=input]]:has-[[data-slot=increment]]:pr-1.25em [&>[data-slot=input]]:has-[[data-slot=decrement]]:pl-1.25em',
   'number-field-decrement': 'grid place-items-center absolute top-1/2 -translate-y-1/2 left-0 p-0.75em disabled:cursor-not-allowed disabled:opacity-20',
-  'number-field-input': 'flex w-full rounded-md bg-transparent h-2.5714285714285716em py-0.2857142857142857em text-0.875em text-center shadow-sm transition-colors placeholder:text-muted disabled:n-disabled focus-visible:outline-none',
+  'number-field-input': 'flex w-full rounded-md bg-transparent h-2.5714285714285716em py-0.2857142857142857em text-0.875em text-center shadow-sm transition-colors placeholder:text-muted-foreground disabled:n-disabled focus-visible:outline-none',
   'number-field-increment': 'grid place-items-center absolute top-1/2 -translate-y-1/2 right-0 disabled:cursor-not-allowed disabled:opacity-20 p-0.75em',
 }
 


### PR DESCRIPTION
`text-muted` resolves to `--una-muted`, the muted **background** token (`gray-100` light / `gray-800` dark), so using it as a text colour gives near-invisible text. Three shortcuts were doing that:

- `form-group-counter-separator`
- `form-group-counter-max`
- `number-field-input`'s `placeholder:`

All three now use `text-muted-foreground` (`gray-500` / `gray-400`), which is what their own neighbours already do — the general `input` shortcut styles its placeholder with `text-muted-foreground`, and `FormGroup.vue` defaults its description to the same.

## Not changed

`text-muted` appears in a few other places where it is **not** a utility class but una's `{variant}-{color}` form, and those are correct as they stand:

- `TabsTrigger.vue`'s `tabsInactive: 'text-muted'` — a `btn` prop value resolving through `btn-text-muted` to `text-muted-foreground/90`. Verified in the browser: an inactive tab computes to `oklch(0.7713 0.0169 99.0657)`, a light colour on a dark background.
- `breadcrumb-inactive`, the `toggle-off` example, and the `btn="text-muted"` docs examples — same pattern.

Spotted while working on #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
