### PR TITLE
feat(Skeleton): render through Primitive so `as` can change the tag

### DIFF
--- a/docs/components/content/examples/vue/skeleton/ExampleVueSkeletonElement.vue
+++ b/docs/components/content/examples/vue/skeleton/ExampleVueSkeletonElement.vue
@@ -1,0 +1,6 @@
+<template>
+  <p class="w-64 space-y-2">
+    <NSkeleton as="span" class="block h-3 w-full" />
+    <NSkeleton as="span" class="block h-3 w-2/3" />
+  </p>
+</template>

--- a/docs/content/3.components/skeleton.md
+++ b/docs/content/3.components/skeleton.md
@@ -52,15 +52,13 @@ badges:
 
 ### Element
 
-| Prop      | Default | Type                  | Description                                             |
-| --------- | ------- | --------------------- | ------------------------------------------------------- |
-| `as`      | `div`   | `string \| Component` | Change the element the skeleton renders as.             |
-| `asChild` | `false` | `boolean`             | Render the child element directly instead of a wrapper. |
+| Prop      | Default | Type                | Description                                             |
+| --------- | ------- | ------------------- | ------------------------------------------------------- |
+| `as`      | `div`   | `AsTag`,`Component` | Change the element the skeleton renders as.             |
+| `asChild` | `false` | `boolean`           | Render the child element directly instead of a wrapper. |
 
-A `div` is not valid inside a `p`, and the parser closes the paragraph at its start tag — which
-lifts the placeholder out as a sibling and leaves the hydrated DOM a different shape from the one
-Vue rendered. Render the skeleton `as="span"` for a placeholder in flowing text. A `span` is
-inline, so give it `block` (or `inline-block`) to keep its height.
+Use `as="span"` inside a `<p>` — a `div` there is invalid and the parser closes the paragraph
+early, breaking hydration. Add `block` or `inline-block` so the span keeps its height.
 
 :::CodeGroup
 ::div{label="Preview" preview}

--- a/docs/content/3.components/skeleton.md
+++ b/docs/content/3.components/skeleton.md
@@ -52,10 +52,10 @@ badges:
 
 ### Element
 
-| Prop      | Default | Type                | Description                                             |
-| --------- | ------- | ------------------- | ------------------------------------------------------- |
-| `as`      | `div`   | `AsTag`,`Component` | Change the element the skeleton renders as.             |
-| `asChild` | `false` | `boolean`           | Render the child element directly instead of a wrapper. |
+| Prop      | Default | Type                 | Description                                             |
+| --------- | ------- | -------------------- | ------------------------------------------------------- |
+| `as`      | `div`   | `AsTag`, `Component` | Change the element the skeleton renders as.             |
+| `asChild` | `false` | `boolean`            | Render the child element directly instead of a wrapper. |
 
 Use `as="span"` inside a `<p>` — a `div` there is invalid and the parser closes the paragraph
 early, breaking hydration. Add `block` or `inline-block` so the span keeps its height.

--- a/docs/content/3.components/skeleton.md
+++ b/docs/content/3.components/skeleton.md
@@ -50,6 +50,27 @@ badges:
 ::
 :::
 
+### Element
+
+| Prop      | Default | Type                  | Description                                             |
+| --------- | ------- | --------------------- | ------------------------------------------------------- |
+| `as`      | `div`   | `string \| Component` | Change the element the skeleton renders as.             |
+| `asChild` | `false` | `boolean`             | Render the child element directly instead of a wrapper. |
+
+A `div` is not valid inside a `p`, and the parser closes the paragraph at its start tag — which
+lifts the placeholder out as a sibling and leaves the hydrated DOM a different shape from the one
+Vue rendered. Render the skeleton `as="span"` for a placeholder in flowing text. A `span` is
+inline, so give it `block` (or `inline-block`) to keep its height.
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueSkeletonElement
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/skeleton/ExampleVueSkeletonElement.vue
+::
+:::
+
 ## Slots
 
 | Name      | Props | Description       |

--- a/packages/nuxt/src/runtime/components/elements/Skeleton.vue
+++ b/packages/nuxt/src/runtime/components/elements/Skeleton.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import type { NSkeletonProps } from '../../types'
+import { Primitive } from 'reka-ui'
 import { cn } from '../../utils'
 
-const props = defineProps<NSkeletonProps>()
+const props = withDefaults(defineProps<NSkeletonProps>(), {
+  as: 'div',
+  asChild: false,
+})
 </script>
 
 <template>
-  <div
+  <Primitive
+    :as="as"
+    :as-child="asChild"
     :class="
       cn(
         'skeleton',
@@ -19,5 +25,5 @@ const props = defineProps<NSkeletonProps>()
     :rounded
   >
     <slot />
-  </div>
+  </Primitive>
 </template>

--- a/packages/nuxt/src/runtime/components/elements/Skeleton.vue
+++ b/packages/nuxt/src/runtime/components/elements/Skeleton.vue
@@ -12,6 +12,7 @@ const props = withDefaults(defineProps<NSkeletonProps>(), {
   <Primitive
     :as
     :as-child
+    aria-busy="true"
     :class="
       cn(
         'skeleton',

--- a/packages/nuxt/src/runtime/components/elements/Skeleton.vue
+++ b/packages/nuxt/src/runtime/components/elements/Skeleton.vue
@@ -5,14 +5,13 @@ import { cn } from '../../utils'
 
 const props = withDefaults(defineProps<NSkeletonProps>(), {
   as: 'div',
-  asChild: false,
 })
 </script>
 
 <template>
   <Primitive
-    :as="as"
-    :as-child="asChild"
+    :as
+    :as-child
     :class="
       cn(
         'skeleton',

--- a/packages/nuxt/src/runtime/types/skeleton.ts
+++ b/packages/nuxt/src/runtime/types/skeleton.ts
@@ -1,8 +1,9 @@
+import type { PrimitiveProps } from 'reka-ui'
 import type { HTMLAttributes } from 'vue'
 
 interface Extensions { class?: HTMLAttributes['class'] }
 
-export interface NSkeletonProps extends Extensions {
+export interface NSkeletonProps extends PrimitiveProps, Extensions {
   /**
    * Allows you to add `UnaUI` skeleton preset properties,
    * Think of it as a shortcut for adding options or variants to the preset if available.


### PR DESCRIPTION
Closes #609

## Problem

`NSkeleton`'s root is a hardcoded `<div>`, so it cannot be used anywhere the surrounding element only accepts phrasing content.

The case that surfaced it is `NCard`. `#description` is rendered through `CardDescription`, which is a `<p>`:

```vue
<NCard>
  <template #description>
    <NSkeleton class="h-3 w-56" />
  </template>
</NCard>
```

`<p>` is one of the few elements with an **end-tag-omission rule** — the HTML parser closes it at a `<div>` start tag. So this:

```html
<p class="card-description"><div class="skeleton"></div></p>
```

parses as:

```html
<p class="card-description"></p><div class="skeleton"></div>
```

The placeholder ends up a *sibling* of the paragraph. Under SSR the hydrated DOM is a different shape from the one Vue rendered, and hydration mismatches. In the app where this came up, a card header authored 3 children and parsed as 5.

Worth noting the asymmetry, because it explains the blast radius: `CardTitle` is an `<h3>`, and a `<div>` inside `<h3>` is *also* invalid per the content model — but `<h3>` has no end-tag-omission rule, so the parser leaves it where Vue put it. Only paragraph slots actually break.

## Change

Render through reka-ui's `Primitive` with `as` / `asChild`, so the tag can be chosen at the call site:

```vue
<NSkeleton as="span" class="block h-3 w-56" />
```

This is the pattern **17 other components in this package already use** — `SidebarGroupLabel.vue` is the closest match — and the types follow the same `extends PrimitiveProps` shape as **15 other** prop interfaces.

- `as` defaults to `'div'`, so existing markup and rendered output are unchanged.
- Everything the component already bound (`class`, `skeleton`, `size`, `rounded`) still reaches the rendered element — `Primitive` sets `inheritAttrs: false` and spreads `attrs` onto the tag it renders.

## Docs

Adds an **Element** section with a prop table and an example. It calls out one thing that is easy to trip on: the `skeleton` shortcut sets animation, radius, height, width and background, but **no `display`**. A `<span>` is inline, so `as="span"` still needs `block` (or `inline-block`) or the placeholder collapses.

The Props and Components blocks in the docs embed the source files directly, so those pick up `as` / `asChild` automatically.

## Verification

- `eslint` clean on all four changed files.
- `vue-tsc --noEmit` — **0 errors** across the repo.
- **SSR-rendered to confirm the output**, rather than inferred:

```
DEFAULT  : <p class="card-description"><div class="skeleton h-3 w-56">…</div></p>
AS=SPAN  : <p class="card-description"><span class="skeleton block h-3 w-56" skeleton="gray">…</span></p>
VARIANTS : <p class="card-description"><span class="skeleton block" size="sm" rounded="full">…</span></p>
```

The default case is byte-identical to the current output, so this is backwards compatible; `skeleton`, `size` and `rounded` all still land on the element.

`test/index.test.ts` is a placeholder suite with no component coverage, so there was nothing to update. That render check would make a reasonable real test, but it needs `@vitejs/plugin-vue` wired into a vitest config — happy to do that separately if wanted.

## Note for the `v1.0.0` port

`Skeleton.vue` differs between branches — `v1.0.0` carries a `skeleton: 'gray'` default that `main` does not. Cherry-picking will conflict on the `withDefaults` block; keep that default and add `as` / `asChild` alongside it:

```ts
const props = withDefaults(defineProps<NSkeletonProps>(), {
  skeleton: 'gray',
  as: 'div',
})
```

Nothing else differs — `types/skeleton.ts` and the docs page are identical on both branches.

## Review follow-ups

Two commits on top of the original change:

**`chore`** — `asChild: false` dropped from `withDefaults`. `Primitive` already defaults it, and no other `Primitive`-based component here (`AvatarGroup`, `TableCell`) declares it. Bindings switched to the same-name shorthand (`:as`, `:as-child`) the rest of the codebase uses, and the docs paragraph cut to the actionable advice.

**`feat`** — `aria-busy="true"` on the placeholder, so assistive tech is told the region is still resolving. Verified in the browser that a consumer-supplied `aria-busy` still wins over the default.

Deliberately *not* following Nuxt UI's Skeleton the rest of the way — it also sets `role="alert"`, `aria-live="polite"` and `aria-label="loading"`. `role="alert"` implies an assertive live region, so a list of N placeholders becomes N announcements; the `aria-live="polite"` alongside it contradicts that role; and a hardcoded English label is not translatable in a component library. Live-region semantics belong on the container that swaps loading → loaded, not on each placeholder.

## Verification (re-run after follow-ups)

- `eslint` clean, `vue-tsc --noEmit` — 0 errors across the repo.
- Docs dev server: the two `as="span"` placeholders stay *inside* the `<p>` (256×12px, confirming `block` restores sizing), the other 15 skeletons still render `div`, all 17 carry `aria-busy="true"`, no console or server errors.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Skeleton components can now render as different HTML elements, including inline elements such as `span`.
  - Added support for rendering skeleton content through child elements.
  - Added documentation and Vue examples for customizing skeleton element rendering.

- **Bug Fixes**
  - Improved compatibility when using skeleton placeholders inside paragraph content, helping prevent invalid HTML and hydration mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
