### PR TITLE
fix(Toast): stop rich toasts overflowing the viewport at narrow widths

### DIFF
--- a/packages/preset/src/_shortcuts/toast.ts
+++ b/packages/preset/src/_shortcuts/toast.ts
@@ -6,8 +6,10 @@ type ToastPrefix = 'toast'
  * the content layout and the button styling.
  */
 export const staticToast: Record<`${ToastPrefix}-${string}` | ToastPrefix, string> = {
-  // mirrors sonner's card so rich toasts sit flush with the standard ones
-  'toast': 'w-[var(--width)] overflow-hidden p-4 text-13px bg-popover text-popover-foreground border border-border rounded-[var(--border-radius)] shadow-lg',
+  // mirrors sonner's card so rich toasts sit flush with the standard ones.
+  // Below sonner's own 600px breakpoint it stretches the `li` instead: sonner
+  // sizes that to the viewport there, and `--width` would overflow it.
+  'toast': 'w-[var(--width)] [@media(max-width:600px)]:w-full overflow-hidden p-4 text-13px bg-popover text-popover-foreground border border-border rounded-[var(--border-radius)] shadow-lg',
   'toast-stack': 'flex flex-col gap-1.5',
   'toast-row': 'flex items-start gap-3',
   'toast-content': 'flex flex-col gap-1 min-w-0 flex-1',


### PR DESCRIPTION
Closes #611

## Problem

Below 600px viewport width, a toast that carries an action button renders wider than the viewport and gets clipped at the right edge. This is viewport-driven, not device-driven — it reproduces on a phone *and* on a desktop browser with the window narrowed.

`toast` pinned the card to `w-[var(--width)]` (356px by default). Below 600px, sonner's own stylesheet sizes the `li` wrapper to `calc(100% - var(--mobile-offset-left) * 2)`, so the fixed-width card ran past it. Measured at a 360px viewport before the fix:

| element | width | right edge |
| --- | --- | --- |
| `[data-sonner-toast]` wrapper | 328px | 344px |
| `.toast` card | **356px** | **372px** (12px off-screen) |

Only toasts that render through `Toast.vue` were affected — the ones with `action`/`cancel`/`actions`, `showProgress`, `leading` or `una`. Standard toasts use sonner's own markup, which that media query already sizes, which is why the bug looked specific to the action button.

## Fix

Match sonner at its own breakpoint: keep `--width` above 600px, fill the wrapper below it.

```diff
-'toast': 'w-[var(--width)] overflow-hidden …'
+'toast': 'w-[var(--width)] [@media(max-width:600px)]:w-full overflow-hidden …'
```

The literal 600px mirrors sonner's `@media (max-width: 600px)` block — a preset breakpoint (`lt-sm`, 640px) would leave a 600–640px band where `w-full` resolves against the shrink-to-fit wrapper and the card would collapse to its content width.

## Verification

Card width vs. its wrapper across a viewport sweep after the change (docs site, "Action" toast) — they agree everywhere, including across the 600/601 boundary, and nothing extends past the viewport:

| viewport | 320 | 360 | 414 | 540 | 599 | 600 | 601 | 768 | 1024 | 1280 | 1440 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| wrapper | 288 | 328 | 382 | 508 | 567 | 568 | 356 | 356 | 356 | 356 | 356 |
| card | 288 | 328 | 382 | 508 | 567 | 568 | 356 | 356 | 356 | 356 | 356 |

At 360px the card was 356px before the fix (12px off-screen); it is now 328px, flush with its wrapper. Desktop widths are unchanged at 356px.

Also checked at desktop width across every toast variant in the playground and docs (all types, action/cancel/multi-action, progress, promise, `una` overrides, plus long titles and long action labels): no clipping, no child overflowing the card, and correct stack geometry both collapsed and hover-expanded.

Confirmed against a production build (`nuxi build`), not just dev — the emitted CSS has `@media (max-width:600px){.toast{width:100%}}` ordered after the base `.toast` rule, and re-measuring the served build at 360px gives the same 328px.

`eslint` and `vitest` pass.