### PR TITLE
fix(MessageScroller): keep autoScroll following when the reader never left the live edge

### DIFF
--- a/packages/nuxt/src/runtime/components/message-scroller/MessageScrollerViewport.vue
+++ b/packages/nuxt/src/runtime/components/message-scroller/MessageScrollerViewport.vue
@@ -2,7 +2,7 @@
 import type { NMessageScrollerViewportProps } from '../../types'
 import { onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue'
 import { cn } from '../../utils'
-import { SCROLL_KEYS, useMessageScrollerContext } from './useMessageScroller'
+import { isScrollTowardStartKey, SCROLL_KEYS, useMessageScrollerContext } from './useMessageScroller'
 
 const props = withDefaults(defineProps<NMessageScrollerViewportProps>(), {
   preserveScrollOnPrepend: true,
@@ -22,9 +22,27 @@ const viewportEl = useTemplateRef<HTMLElement>('viewport')
 
 watch(() => props.preserveScrollOnPrepend, setPreserveScrollOnPrepend, { immediate: true })
 
+// Only a gesture that carries the reader toward the start releases autoScroll:
+// wheeling or paging down while already at the live edge moves nothing.
+function onWheel(event: WheelEvent) {
+  userScrollIntent(event.deltaY < 0)
+}
+
+let touchStartY: number | null = null
+
+function onTouchStart(event: TouchEvent) {
+  touchStartY = event.touches[0]?.clientY ?? null
+}
+
+function onTouchMove(event: TouchEvent) {
+  const y = event.touches[0]?.clientY ?? null
+  // dragging the finger down pulls the transcript toward the start
+  userScrollIntent(touchStartY === null || y === null ? true : y > touchStartY)
+}
+
 function onKeyDown(event: KeyboardEvent) {
   if (SCROLL_KEYS.has(event.key))
-    userScrollIntent()
+    userScrollIntent(isScrollTowardStartKey(event))
 }
 
 let resizeObserver: ResizeObserver | null = null
@@ -65,8 +83,9 @@ onBeforeUnmount(() => {
       props.class,
     )"
     @scroll="syncAfterScroll()"
-    @wheel="userScrollIntent()"
-    @touchmove="userScrollIntent()"
+    @wheel="onWheel"
+    @touchstart="onTouchStart"
+    @touchmove="onTouchMove"
     @keydown="onKeyDown"
   >
     <slot />

--- a/packages/nuxt/src/runtime/components/message-scroller/useMessageScroller.ts
+++ b/packages/nuxt/src/runtime/components/message-scroller/useMessageScroller.ts
@@ -774,6 +774,9 @@ function createEngine(props: NMessageScrollerProviderProps) {
    * live edge. Growth moves the edge before it can be measured, so a reader who
    * never scrolls away would otherwise never satisfy the at-the-edge test again
    * and would be left behind until they used a scroll button.
+   *
+   * Deliberate divergence from the shadcn-vue source, which has no re-entry
+   * here at all — keep it when diffing against upstream. See #622.
    */
   function resumeFollowingFromLiveEdge() {
     if (!autoScroll() || mode !== 'free-scrolling' || !atLiveEdge)
@@ -884,6 +887,13 @@ function createEngine(props: NMessageScrollerProviderProps) {
 
   // --- user intent + element setters -----------------------------------------
 
+  /**
+   * Release the view when the reader scrolls away from wherever it is holding.
+   *
+   * The `towardStart` test is a deliberate divergence from the shadcn-vue
+   * source, which releases `following-bottom` on any gesture — keep it when
+   * diffing against upstream. See #622.
+   */
   function userScrollIntent(towardStart = true) {
     if (mode === 'anchored-to-message' || mode === 'settling-jump') {
       streamingTurn = null

--- a/packages/nuxt/src/runtime/components/message-scroller/useMessageScroller.ts
+++ b/packages/nuxt/src/runtime/components/message-scroller/useMessageScroller.ts
@@ -28,6 +28,16 @@ const SCROLL_KEYS = new Set([
   ' ',
 ])
 
+const SCROLL_START_KEYS = new Set(['ArrowUp', 'Home', 'PageUp'])
+
+/**
+ * Whether a scroll key carries the reader toward the start of the transcript.
+ * Space pages toward the end unless shifted.
+ */
+function isScrollTowardStartKey(event: KeyboardEvent) {
+  return SCROLL_START_KEYS.has(event.key) || (event.key === ' ' && event.shiftKey)
+}
+
 const EMPTY_SCROLLABLE: NMessageScrollerScrollable = { start: false, end: false }
 const EMPTY_VISIBLE_IDS: string[] = []
 const EMPTY_VISIBILITY: NMessageScrollerVisibilityState = {
@@ -347,7 +357,7 @@ export interface MessageScrollerContext {
   setViewportElement: (element: HTMLElement | null) => void
   setPreserveScrollOnPrepend: (value: boolean) => void
   syncAfterScroll: () => void
-  userScrollIntent: () => void
+  userScrollIntent: (towardStart?: boolean) => void
 }
 
 export type RegisterMessage = (
@@ -376,6 +386,10 @@ function createEngine(props: NMessageScrollerProviderProps) {
   let firstItem: HTMLElement | null = null
   let itemCount = 0
   let lastScrollTop = 0
+  // Whether the reader sat at the live edge as of the last settled measurement.
+  // Content growing pushes the edge away before the growth is measured, so the
+  // pre-growth answer is the one that says whether they were following along.
+  let atLiveEdge = false
   let defaultScrollPositionApplied = false
   let preserveScrollOnPrepend = true
   let prependRestore: PrependRestore | null = null
@@ -432,6 +446,7 @@ function createEngine(props: NMessageScrollerProviderProps) {
       viewport,
     })
     updateModeFromScroll(measured)
+    atLiveEdge = !measured.end
     const next = mode === 'following-bottom'
       ? { ...measured, end: false }
       : measured
@@ -735,7 +750,7 @@ function createEngine(props: NMessageScrollerProviderProps) {
     if (mode === 'following-bottom' && autoScroll()) {
       scrollToEnd({ behavior: 'auto' })
     }
-    else {
+    else if (!resumeFollowingFromLiveEdge()) {
       commitScrollState()
       scheduleVisibilitySync()
     }
@@ -754,11 +769,26 @@ function createEngine(props: NMessageScrollerProviderProps) {
     capturePrependAnchor()
   }
 
+  /**
+   * Re-enter following when content grows under a reader who was sitting at the
+   * live edge. Growth moves the edge before it can be measured, so a reader who
+   * never scrolls away would otherwise never satisfy the at-the-edge test again
+   * and would be left behind until they used a scroll button.
+   */
+  function resumeFollowingFromLiveEdge() {
+    if (!autoScroll() || mode !== 'free-scrolling' || !atLiveEdge)
+      return false
+    mode = 'following-bottom'
+    return scrollToEnd({ behavior: 'auto' })
+  }
+
   function handleResize() {
     if (mode === 'following-bottom' && autoScroll()) {
       scrollToEnd({ behavior: 'auto' })
       return
     }
+    if (resumeFollowingFromLiveEdge())
+      return
     const previousSpacerHeight = spacerHeight
     if (reanchorToAnchoredMessage()) {
       // The reply streaming below the anchor consumes the tail spacer as it
@@ -854,14 +884,22 @@ function createEngine(props: NMessageScrollerProviderProps) {
 
   // --- user intent + element setters -----------------------------------------
 
-  function userScrollIntent() {
-    if (
-      mode === 'following-bottom'
-      || mode === 'anchored-to-message'
-      || mode === 'settling-jump'
-    ) {
+  function userScrollIntent(towardStart = true) {
+    if (mode === 'anchored-to-message' || mode === 'settling-jump') {
       streamingTurn = null
       mode = 'free-scrolling'
+      // the reader is leaving: drop the stale at-the-edge answer so a content
+      // growth landing before their scroll event cannot pull them back
+      atLiveEdge = false
+      return
+    }
+    // Only a gesture toward the start takes the reader off the live edge. A
+    // wheel tick or ArrowDown while already pinned to the bottom moves nothing,
+    // so releasing on it would strand autoScroll with the reader still there.
+    if (mode === 'following-bottom' && towardStart) {
+      streamingTurn = null
+      mode = 'free-scrolling'
+      atLiveEdge = false
     }
   }
 
@@ -1010,4 +1048,4 @@ export function useMessageScrollerVisibility(): Ref<NMessageScrollerVisibilitySt
   return computed(() => visibility.value)
 }
 
-export { SCROLL_KEYS }
+export { isScrollTowardStartKey, SCROLL_KEYS }


### PR DESCRIPTION
Stacked on [#620](https://github.com/una-ui/una-ui/pull/620) — retarget to `v1.0.0` once that merges. Closes #622.

`autoScroll` stopped following while the reader was still sitting at the live edge, recoverable only by clicking the scroll button. Both causes came over verbatim from the shadcn-vue source, and both contradict its own documentation:

> Scrolling **away from the live edge** — by wheel, touch, keyboard, or dragging the scrollbar — releases the view

> `autoScroll` — Follow the live edge **while the reader is pinned to the bottom**

## 1. A gesture that moved nothing released the view

`userScrollIntent()` fired from `@wheel` / `@touchmove` / `@keydown` and dropped out of `following-bottom` without checking direction or movement. Measured before the fix — viewport pinned at the bottom, one wheel tick *downward*:

```
wheel deltaY:120 → viewport moved 0px
  append → 88px below the fold
  append → 176px below the fold
  ↓ button → follows again
```

Now only a gesture toward the start releases: `deltaY < 0`, a touch drag downward, or `ArrowUp` / `PageUp` / `Home` / `Shift+Space`. Anchored and settling holds still release on any gesture — that branch is unchanged.

## 2. A stream could never re-arm

Re-entry only happened when a measurement caught the reader within `scrollEdgeThreshold` (8px) of the edge, but each streamed line moves the edge ~12–30px *before* the growth is measured, and no other event fires while the reader sits still:

```
gap while sitting at the bottom mid-stream:  0 → 12 → 12 → 12 → 32 → 32
```

The engine now records whether the reader was at the live edge as of the last settled measurement and resumes following from that pre-growth answer. Releasing clears the flag, so a reader who genuinely scrolls away isn't yanked back by a growth that lands before their scroll event.

```
after the fix:  0 → 12 → 0 → 0 → 0 → 0
```

## Verified

| case | result |
|---|---|
| no-op wheel down at the bottom → append | follows |
| `ArrowDown` at the bottom → append | follows |
| genuine scroll up → append | released, reader held in place |
| return to the edge → append | resumes following |
| mid-stream: scroll away | held, no yank-back |
| mid-stream: return to the edge | resumes |
| prepend, reader mid-history | position preserved to the pixel (0px) |
| prepend, reader at the live edge | identical to pre-fix baseline (0px, still at bottom) |
| anchored turn pin + spacer, scroll button | unchanged |

`vue-tsc --noEmit` and eslint clean.

This is the first behavioural divergence from the snapshot port, so it's recorded on the map rather than folded into #620. Worth reporting upstream as well — the repro is a single wheel event.