### PR TITLE
docs: MessageScroller page and a Utilities section for the scroll utilities

### DIFF
--- a/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerAnchor.vue
+++ b/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerAnchor.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+interface Message {
+  id: string
+  role: 'user' | 'assistant'
+  text: string
+}
+
+const messages = ref<Message[]>([
+  { id: 'm1', role: 'user', text: 'First question of the thread.' },
+  { id: 'm2', role: 'assistant', text: 'And the answer to it, which is long enough to take up a bit of room in the transcript so there is something to scroll past.' },
+  { id: 'm3', role: 'user', text: 'A follow-up question.' },
+  { id: 'm4', role: 'assistant', text: 'Another answer. Each user turn is marked as a scroll anchor, so a new turn is moved to the top of the viewport with a peek of the previous exchange left above it.' },
+])
+
+let uid = 4
+
+function askAgain() {
+  uid += 1
+  messages.value.push({ id: `m${uid}`, role: 'user', text: `Question ${Math.ceil(uid / 2)} — watch this one move to the top.` })
+  uid += 1
+  messages.value.push({ id: `m${uid}`, role: 'assistant', text: 'The reply lands underneath the anchored question, so the turn reads from its beginning instead of appearing halfway up the viewport.' })
+}
+</script>
+
+<template>
+  <div class="w-full flex flex-col gap-3">
+    <NButton btn="outline-gray" size="sm" label="Ask a new question" class="self-start" @click="askAgain" />
+
+    <div class="h-80 border rounded-lg bg-background">
+      <NMessageScrollerProvider auto-scroll default-scroll-position="last-anchor">
+        <NMessageScroller>
+          <NMessageScrollerViewport>
+            <NMessageScrollerContent class="p-4">
+              <NMessageScrollerItem
+                v-for="message in messages"
+                :key="message.id"
+                :message-id="message.id"
+                :scroll-anchor="message.role === 'user'"
+              >
+                <div
+                  class="max-w-[80%] rounded-lg px-3 py-2 text-sm"
+                  :class="message.role === 'user'
+                    ? 'ml-auto bg-primary text-primary-foreground'
+                    : 'bg-muted text-foreground'"
+                >
+                  {{ message.text }}
+                </div>
+              </NMessageScrollerItem>
+            </NMessageScrollerContent>
+          </NMessageScrollerViewport>
+
+          <NMessageScrollerButton />
+        </NMessageScroller>
+      </NMessageScrollerProvider>
+    </div>
+  </div>
+</template>

--- a/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerAutoScroll.vue
+++ b/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerAutoScroll.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+interface Message {
+  id: string
+  role: 'user' | 'assistant'
+  text: string
+}
+
+const REPLY = 'While a reply streams, the viewport stays pinned to the live edge. Scroll up and it lets go — new chunks arrive without moving you. Come back to the bottom and it picks the thread up again.'
+
+const messages = ref<Message[]>([
+  { id: 'm1', role: 'user', text: 'Stream me something long enough to scroll.' },
+  { id: 'm2', role: 'assistant', text: REPLY },
+])
+
+const streaming = ref(false)
+let timer: ReturnType<typeof setInterval> | null = null
+let uid = 2
+
+function stop() {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+  streaming.value = false
+}
+
+function stream() {
+  if (streaming.value)
+    return
+  uid += 1
+  messages.value.push({ id: `m${uid}`, role: 'user', text: 'Once more, please.' })
+  uid += 1
+  messages.value.push({ id: `m${uid}`, role: 'assistant', text: '' })
+  // mutate through the array proxy so every chunk triggers reactivity
+  const reply = messages.value[messages.value.length - 1]!
+  streaming.value = true
+
+  const words = `${REPLY} ${REPLY}`.split(' ')
+  let index = 0
+  timer = setInterval(() => {
+    if (index >= words.length) {
+      stop()
+      return
+    }
+    reply.text += `${words[index]} `
+    index += 1
+  }, 70)
+}
+
+onBeforeUnmount(stop)
+</script>
+
+<template>
+  <div class="w-full flex flex-col gap-3">
+    <NButton
+      btn="outline-gray"
+      size="sm"
+      label="Stream a reply"
+      class="self-start"
+      :disabled="streaming"
+      @click="stream"
+    />
+
+    <div class="h-80 border rounded-lg bg-background">
+      <NMessageScrollerProvider auto-scroll>
+        <NMessageScroller>
+          <NMessageScrollerViewport>
+            <NMessageScrollerContent class="p-4">
+              <NMessageScrollerItem
+                v-for="message in messages"
+                :key="message.id"
+                :message-id="message.id"
+              >
+                <div
+                  class="max-w-[80%] rounded-lg px-3 py-2 text-sm"
+                  :class="message.role === 'user'
+                    ? 'ml-auto bg-primary text-primary-foreground'
+                    : 'bg-muted text-foreground'"
+                >
+                  {{ message.text }}
+                </div>
+              </NMessageScrollerItem>
+            </NMessageScrollerContent>
+          </NMessageScrollerViewport>
+
+          <NMessageScrollerButton />
+        </NMessageScroller>
+      </NMessageScrollerProvider>
+    </div>
+  </div>
+</template>

--- a/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerBasic.vue
+++ b/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerBasic.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+const messages = [
+  { id: 'm1', role: 'user', text: 'What does a message scroller actually have to do?' },
+  { id: 'm2', role: 'assistant', text: 'Keep the reader where they expect to be. That means following a reply while it streams, but never fighting someone who scrolls up to re-read something.' },
+  { id: 'm3', role: 'user', text: 'And when older history loads above?' },
+  { id: 'm4', role: 'assistant', text: 'The reading position is preserved — the message you were looking at stays exactly where it was, instead of being pushed down the page.' },
+  { id: 'm5', role: 'user', text: 'What about jumping around the thread?' },
+  { id: 'm6', role: 'assistant', text: 'Every item can carry a messageId, so you can scroll to any of them on demand, with the alignment you want.' },
+]
+</script>
+
+<template>
+  <div class="h-80 w-full border rounded-lg bg-background">
+    <NMessageScrollerProvider>
+      <NMessageScroller>
+        <NMessageScrollerViewport>
+          <NMessageScrollerContent class="p-4">
+            <NMessageScrollerItem
+              v-for="message in messages"
+              :key="message.id"
+              :message-id="message.id"
+            >
+              <div
+                class="max-w-[80%] rounded-lg px-3 py-2 text-sm"
+                :class="message.role === 'user'
+                  ? 'ml-auto bg-primary text-primary-foreground'
+                  : 'bg-muted text-foreground'"
+              >
+                {{ message.text }}
+              </div>
+            </NMessageScrollerItem>
+          </NMessageScrollerContent>
+        </NMessageScrollerViewport>
+
+        <NMessageScrollerButton />
+      </NMessageScroller>
+    </NMessageScrollerProvider>
+  </div>
+</template>

--- a/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerJump.vue
+++ b/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerJump.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+const messages = Array.from({ length: 5 }, (_, turn) => [
+  {
+    id: `q${turn + 1}`,
+    role: 'user' as const,
+    text: `Question ${turn + 1} — the anchor for this turn.`,
+  },
+  {
+    id: `a${turn + 1}`,
+    role: 'assistant' as const,
+    text: `Answer ${turn + 1}. Long enough that the turns do not all fit at once, so jumping between them actually moves the viewport and the visibility state changes as you go.`,
+  },
+]).flat()
+
+const targets = Array.from({ length: 5 }, (_, turn) => ({
+  id: `q${turn + 1}`,
+  label: `Turn ${turn + 1}`,
+}))
+</script>
+
+<template>
+  <NMessageScrollerProvider default-scroll-position="start">
+    <div class="w-full flex flex-col gap-3">
+      <div class="h-80 border rounded-lg bg-background">
+        <NMessageScroller>
+          <NMessageScrollerViewport>
+            <NMessageScrollerContent class="p-4">
+              <NMessageScrollerItem
+                v-for="message in messages"
+                :key="message.id"
+                :message-id="message.id"
+                :scroll-anchor="message.role === 'user'"
+              >
+                <div
+                  class="max-w-[80%] rounded-lg px-3 py-2 text-sm"
+                  :class="message.role === 'user'
+                    ? 'ml-auto bg-primary text-primary-foreground'
+                    : 'bg-muted text-foreground'"
+                >
+                  {{ message.text }}
+                </div>
+              </NMessageScrollerItem>
+            </NMessageScrollerContent>
+          </NMessageScrollerViewport>
+
+          <NMessageScrollerButton direction="start" />
+          <NMessageScrollerButton />
+        </NMessageScroller>
+      </div>
+
+      <ExampleVueMessageScrollerJumpControls :targets="targets" />
+    </div>
+  </NMessageScrollerProvider>
+</template>

--- a/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerJumpControls.vue
+++ b/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerJumpControls.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+// The composables read the scroller's context, so they have to be called from a
+// component rendered inside NMessageScrollerProvider — not from the component
+// that renders the provider itself.
+defineProps<{
+  targets: { id: string, label: string }[]
+}>()
+
+const { scrollToMessage } = useMessageScroller()
+const visibility = useMessageScrollerVisibility()
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center gap-2">
+    <NButton
+      v-for="target in targets"
+      :key="target.id"
+      btn="outline-gray"
+      size="sm"
+      :label="target.label"
+      @click="scrollToMessage(target.id, { align: 'start' })"
+    />
+
+    <span class="ml-auto text-xs text-muted-foreground">
+      current turn: <code>{{ visibility.currentAnchorId ?? '—' }}</code>
+      · visible: <code>{{ visibility.visibleMessageIds.length }}</code>
+    </span>
+  </div>
+</template>

--- a/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerPrepend.vue
+++ b/docs/components/content/examples/vue/message-scroller/ExampleVueMessageScrollerPrepend.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+interface Message {
+  id: string
+  role: 'user' | 'assistant'
+  text: string
+}
+
+let oldest = 0
+
+function olderPage(): Message[] {
+  return Array.from({ length: 4 }, (_, i) => {
+    oldest -= 1
+    return {
+      id: `old${oldest}`,
+      role: (i % 2 === 0 ? 'user' : 'assistant') as Message['role'],
+      text: `Older message ${oldest}. Loading history above the reader must not move the message they are reading.`,
+    }
+  }).reverse()
+}
+
+const messages = ref<Message[]>([
+  { id: 'm1', role: 'user', text: 'Scroll to the top and load the history above.' },
+  { id: 'm2', role: 'assistant', text: 'The scroller records where the first visible message sits, then puts it back after the prepend — so the transcript grows upward without the page jumping under you.' },
+  { id: 'm3', role: 'user', text: 'Try it a few times in a row.' },
+  { id: 'm4', role: 'assistant', text: 'Each page of history is added above, and your reading position stays put to the pixel.' },
+])
+
+function loadOlder() {
+  messages.value.unshift(...olderPage())
+}
+</script>
+
+<template>
+  <div class="w-full flex flex-col gap-3">
+    <NButton btn="outline-gray" size="sm" label="Load older messages" class="self-start" @click="loadOlder" />
+
+    <div class="h-80 border rounded-lg bg-background">
+      <NMessageScrollerProvider>
+        <NMessageScroller>
+          <NMessageScrollerViewport>
+            <NMessageScrollerContent class="p-4">
+              <NMessageScrollerItem
+                v-for="message in messages"
+                :key="message.id"
+                :message-id="message.id"
+              >
+                <div
+                  class="max-w-[80%] rounded-lg px-3 py-2 text-sm"
+                  :class="message.role === 'user'
+                    ? 'ml-auto bg-primary text-primary-foreground'
+                    : 'bg-muted text-foreground'"
+                >
+                  {{ message.text }}
+                </div>
+              </NMessageScrollerItem>
+            </NMessageScrollerContent>
+          </NMessageScrollerViewport>
+
+          <NMessageScrollerButton direction="start" />
+          <NMessageScrollerButton />
+        </NMessageScroller>
+      </NMessageScrollerProvider>
+    </div>
+  </div>
+</template>

--- a/docs/components/content/examples/vue/scroll-fade/ExampleVueScrollFadeBasic.vue
+++ b/docs/components/content/examples/vue/scroll-fade/ExampleVueScrollFadeBasic.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+const rows = Array.from({ length: 24 }, (_, i) => `Row ${i + 1}`)
+</script>
+
+<template>
+  <div class="w-full flex flex-wrap gap-6">
+    <div class="h-56 w-56 overflow-y-auto border rounded-lg p-4 scrollbar-thin scroll-fade">
+      <div v-for="row in rows" :key="row" class="py-1 text-sm">
+        {{ row }}
+      </div>
+    </div>
+
+    <div class="h-56 w-56 overflow-y-auto border rounded-lg p-4 scrollbar-thin scroll-fade-b">
+      <div v-for="row in rows" :key="row" class="py-1 text-sm">
+        {{ row }}
+      </div>
+    </div>
+
+    <div class="h-56 w-56 overflow-y-auto border rounded-lg p-4 scrollbar-thin scroll-fade-t">
+      <div v-for="row in rows" :key="row" class="py-1 text-sm">
+        {{ row }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/components/content/examples/vue/scroll-fade/ExampleVueScrollFadeHorizontal.vue
+++ b/docs/components/content/examples/vue/scroll-fade/ExampleVueScrollFadeHorizontal.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const tags = Array.from({ length: 20 }, (_, i) => `tag-${i + 1}`)
+</script>
+
+<template>
+  <div class="w-full flex flex-col gap-6">
+    <div class="w-full flex gap-3 overflow-x-auto border rounded-lg p-4 no-scrollbar scroll-fade-x">
+      <div v-for="tag in tags" :key="tag" class="shrink-0 rounded-md bg-muted px-3 py-2 text-sm">
+        {{ tag }}
+      </div>
+    </div>
+
+    <div class="w-full flex gap-3 overflow-x-auto border rounded-lg p-4 no-scrollbar scroll-fade-e">
+      <div v-for="tag in tags" :key="tag" class="shrink-0 rounded-md bg-muted px-3 py-2 text-sm">
+        {{ tag }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/components/content/examples/vue/scroll-fade/ExampleVueScrollFadeSize.vue
+++ b/docs/components/content/examples/vue/scroll-fade/ExampleVueScrollFadeSize.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+const rows = Array.from({ length: 24 }, (_, i) => `Row ${i + 1}`)
+</script>
+
+<template>
+  <div class="w-full flex flex-wrap gap-6">
+    <div class="h-56 w-56 overflow-y-auto border rounded-lg p-4 scrollbar-thin scroll-fade-b">
+      <div v-for="row in rows" :key="row" class="py-1 text-sm">
+        {{ row }}
+      </div>
+    </div>
+
+    <div class="h-56 w-56 overflow-y-auto border rounded-lg p-4 scrollbar-thin scroll-fade-b scroll-fade-b-16">
+      <div v-for="row in rows" :key="row" class="py-1 text-sm">
+        {{ row }}
+      </div>
+    </div>
+
+    <div class="h-56 w-56 overflow-y-auto border rounded-lg p-4 scrollbar-thin scroll-fade-b scroll-fade-b-[4rem]">
+      <div v-for="row in rows" :key="row" class="py-1 text-sm">
+        {{ row }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/components/content/examples/vue/scrollbar/ExampleVueScrollbarBasic.vue
+++ b/docs/components/content/examples/vue/scrollbar/ExampleVueScrollbarBasic.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const rows = Array.from({ length: 24 }, (_, i) => `Row ${i + 1}`)
+</script>
+
+<template>
+  <div class="w-full flex flex-wrap gap-6">
+    <div class="flex flex-col gap-2">
+      <span class="text-xs text-muted-foreground">scrollbar-thin</span>
+      <div class="h-52 w-56 overflow-y-auto border rounded-lg p-4 scrollbar-thin">
+        <div v-for="row in rows" :key="row" class="py-1 text-sm">
+          {{ row }}
+        </div>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <span class="text-xs text-muted-foreground">no-scrollbar</span>
+      <div class="h-52 w-56 overflow-y-auto border rounded-lg p-4 no-scrollbar">
+        <div v-for="row in rows" :key="row" class="py-1 text-sm">
+          {{ row }}
+        </div>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <span class="text-xs text-muted-foreground">scrollbar-gutter-stable</span>
+      <div class="h-52 w-56 overflow-y-auto border rounded-lg p-4 scrollbar-thin scrollbar-gutter-stable">
+        <div v-for="row in rows.slice(0, 3)" :key="row" class="py-1 text-sm">
+          {{ row }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/content/3.components/message-scroller.md
+++ b/docs/content/3.components/message-scroller.md
@@ -1,0 +1,189 @@
+---
+navBadges:
+  - value: New
+    type: lime
+description: 'A scroll container for chat transcripts that anchors turns, follows streamed replies, and restores prepended history.'
+badges:
+  - value: Source
+    icon: radix-icons:github-logo
+    to: https://github.com/una-ui/una-ui/blob/main/packages/nuxt/src/runtime/components/message-scroller/MessageScroller.vue
+    target: _blank
+---
+
+A chat transcript has to juggle several things at once: pin to the live edge while a reply streams in, without fighting a reader who scrolls up; move each new turn near the top so it reads from its beginning; keep the reading position steady when older history loads above; and jump to any message on demand. `MessageScroller` owns those parts so your message list does not have to.
+
+The family is a set of parts you compose:
+
+| Part                       | Role                                                                   |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `NMessageScrollerProvider` | Owns the scroll engine. Renders no markup.                             |
+| `NMessageScroller`         | Positioning root for the viewport and the scroll buttons.              |
+| `NMessageScrollerViewport` | The scroll container itself.                                           |
+| `NMessageScrollerContent`  | The message list, plus the spacer that anchoring grows into.           |
+| `NMessageScrollerItem`     | One message. Carries its id and whether it anchors a turn.             |
+| `NMessageScrollerButton`   | A floating jump-to-edge button that shows itself only when it can act. |
+
+## Examples
+
+### Basic
+
+Wrap the transcript in a provider, put the messages inside the viewport's content, and give each one a `messageId`. Nothing else is required — the button appears only when there is somewhere to scroll.
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueMessageScrollerBasic
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/message-scroller/ExampleVueMessageScrollerBasic.vue
+::
+:::
+
+### Following the live edge
+
+`autoScroll` keeps a streaming reply in view as it grows. Scrolling toward the start — by wheel, touch or keyboard — releases the view, so the following chunks arrive without moving the reader. Returning to the live edge picks the thread back up.
+
+| Prop         | Default | Type      | Description                                             |
+| ------------ | ------- | --------- | ------------------------------------------------------- |
+| `autoScroll` | `false` | `boolean` | Follow the live edge while the reader is sitting at it. |
+
+::alert
+Mutate the streaming message **through the array proxy** (`messages.value[messages.value.length - 1]`), not through a raw object you captured earlier. Assigning the same string back through a stale reference does not trigger reactivity, and the reply will appear to never grow.
+::
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueMessageScrollerAutoScroll
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/message-scroller/ExampleVueMessageScrollerAutoScroll.vue
+::
+:::
+
+### Anchoring turns
+
+A _turn_ is a new exchange — usually a question and the reply that follows it. Mark the row that starts it with `scrollAnchor`, and the viewport moves that row near the top when it arrives, keeping a peek of the previous exchange above it so the turn does not feel detached.
+
+Anchoring is role-independent: a system marker or a "joined the chat" row can anchor a turn just as well as a user message.
+
+| Prop                     | Default | Type                          | Description                                                           |
+| ------------------------ | ------- | ----------------------------- | --------------------------------------------------------------------- |
+| `scrollAnchor`           | `false` | `boolean`                     | Marks the item as the start of a turn. Set on `NMessageScrollerItem`. |
+| `defaultScrollPosition`  | `end`   | `start`, `end`, `last-anchor` | Where the viewport opens. Set on the provider.                        |
+| `scrollPreviousItemPeek` | `64`    | `number`                      | Pixels of the previous item kept visible above an anchored turn.      |
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueMessageScrollerAnchor
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/message-scroller/ExampleVueMessageScrollerAnchor.vue
+::
+:::
+
+### Loading older history
+
+When messages are added above the reader, the scroller restores the position of the first visible message afterwards, so the transcript grows upward without the page jumping. Turn it off with `preserveScrollOnPrepend` on the viewport.
+
+| Prop                      | Default | Type      | Description                                              |
+| ------------------------- | ------- | --------- | -------------------------------------------------------- |
+| `preserveScrollOnPrepend` | `true`  | `boolean` | Hold the reading position when items are added above it. |
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueMessageScrollerPrepend
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/message-scroller/ExampleVueMessageScrollerPrepend.vue
+::
+:::
+
+### Scroll buttons
+
+`NMessageScrollerButton` wraps [`NButton`](/components/button), so every button prop passes through. It hides itself — and goes `inert` — whenever its direction has nowhere to go, and its icon flips for `direction="start"`.
+
+| Prop        | Default         | Type             | Description                       |
+| ----------- | --------------- | ---------------- | --------------------------------- |
+| `direction` | `end`           | `start`, `end`   | Which edge the button scrolls to. |
+| `behavior`  | `smooth`        | `auto`, `smooth` | Scroll behaviour used on click.   |
+| `btn`       | `outline-white` | `string`         | Any button variant.               |
+
+::alert{type="warning"}
+Prefer an opaque variant. The button floats over the transcript, so translucent variants such as `soft` and `ghost` let the messages underneath read through it.
+::
+
+```vue
+<NMessageScroller>
+  <NMessageScrollerViewport>...</NMessageScrollerViewport>
+
+  <NMessageScrollerButton direction="start" btn="solid-gray" />
+  <NMessageScrollerButton label="i-lucide-chevrons-down" />
+</NMessageScroller>
+```
+
+### Jumping to messages
+
+Inside the provider, `useMessageScroller()` exposes the scroll commands and `useMessageScrollerVisibility()` reports which messages are on screen and which turn the reader is in. Both read the provider's context, so call them from a component **rendered inside** `NMessageScrollerProvider`.
+
+| Composable                       | Returns                                                                             |
+| -------------------------------- | ----------------------------------------------------------------------------------- |
+| `useMessageScroller()`           | `scrollToEnd(options?)`, `scrollToStart(options?)`, `scrollToMessage(id, options?)` |
+| `useMessageScrollerScrollable()` | `{ start, end }` — whether either edge can still be scrolled to.                    |
+| `useMessageScrollerVisibility()` | `{ currentAnchorId, visibleMessageIds }`.                                           |
+
+`scrollToMessage` takes an `align` of `start`, `center`, `end` or `nearest`, plus `behavior` and `scrollMargin`.
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueMessageScrollerJump
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/message-scroller/ExampleVueMessageScrollerJump.vue
+::
+::div{label="Controls"}
+@@@ ./components/content/examples/vue/message-scroller/ExampleVueMessageScrollerJumpControls.vue
+::
+:::
+
+### Styling
+
+The viewport ships with the [`scroll-fade`](/utilities/scroll-fade) and scrollbar utilities applied: its bottom edge fades while there is more to read, the scrollbar is thin, and the scrollbar hides itself while the viewport is autoscrolling. Every part takes `class` and a matching `una` key, and the parts expose `data-slot`, `data-scrollable` and `data-autoscrolling` for styling from the outside.
+
+```vue
+<NMessageScrollerViewport
+  class="scroll-fade-b-16"
+  :una="{ messageScrollerViewport: 'no-scrollbar' }"
+/>
+```
+
+## Props
+
+@@@ ../packages/nuxt/src/runtime/types/message-scroller.ts [types/message-scroller.ts]
+
+## Components
+
+:::CodeGroup
+::div{label="MessageScrollerProvider.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/message-scroller/MessageScrollerProvider.vue
+
+::
+::div{label="MessageScroller.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/message-scroller/MessageScroller.vue
+
+::
+::div{label="MessageScrollerViewport.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/message-scroller/MessageScrollerViewport.vue
+
+::
+::div{label="MessageScrollerContent.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/message-scroller/MessageScrollerContent.vue
+
+::
+::div{label="MessageScrollerItem.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/message-scroller/MessageScrollerItem.vue
+
+::
+::div{label="MessageScrollerButton.vue" icon="i-vscode-icons-file-type-vue"}
+@@@ ../packages/nuxt/src/runtime/components/message-scroller/MessageScrollerButton.vue
+
+::
+:::

--- a/docs/content/4.utilities/_dir.yml
+++ b/docs/content/4.utilities/_dir.yml
@@ -1,0 +1,3 @@
+icon: i-lucide-sparkles
+title: Utilities
+navigation.redirect: /utilities/scroll-fade

--- a/docs/content/4.utilities/scroll-fade.md
+++ b/docs/content/4.utilities/scroll-fade.md
@@ -1,0 +1,106 @@
+---
+navBadges:
+  - value: New
+    type: lime
+description: 'Fades the edges of a scroll container, and only while there is content to reveal in that direction.'
+badges:
+  - value: Source
+    icon: radix-icons:github-logo
+    to: https://github.com/una-ui/una-ui/blob/main/packages/preset/src/_rules/scroll-fade.ts
+    target: _blank
+---
+
+`scroll-fade` masks the edges of any scroll container so content dissolves instead of being cut off. Where the browser supports [scroll-driven animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline), each edge only fades while there is something to reveal in that direction: the top edge is sharp when you are at the top, and fades in as you scroll away from it. No JavaScript is involved.
+
+It is a plain utility — it needs no component, and works on anything that scrolls.
+
+```vue
+<div class="h-56 overflow-y-auto scroll-fade">
+  <!-- both edges fade as you scroll -->
+</div>
+```
+
+## Examples
+
+### Edges
+
+`scroll-fade` fades both block edges. Narrow it to one edge when only one of them ever needs it — a chat transcript typically fades the bottom only.
+
+| Class              | Fades                                       |
+| ------------------ | ------------------------------------------- |
+| `scroll-fade`      | both block edges (alias of `scroll-fade-y`) |
+| `scroll-fade-y`    | top and bottom                              |
+| `scroll-fade-x`    | both inline edges                           |
+| `scroll-fade-t`    | top                                         |
+| `scroll-fade-b`    | bottom                                      |
+| `scroll-fade-s`    | inline start (flips under `dir="rtl"`)      |
+| `scroll-fade-e`    | inline end (flips under `dir="rtl"`)        |
+| `scroll-fade-l`    | left, physical                              |
+| `scroll-fade-r`    | right, physical                             |
+| `scroll-fade-none` | removes the mask                            |
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueScrollFadeBasic
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/scroll-fade/ExampleVueScrollFadeBasic.vue
+::
+:::
+
+### Size
+
+The fade defaults to `min(12%, 2.5rem)`. Set it globally with `scroll-fade-<n>` or per edge with `scroll-fade-<edge>-<n>`, where `n` is a spacing step; arbitrary values work too.
+
+| Class                  | Size                         |
+| ---------------------- | ---------------------------- |
+| `scroll-fade-16`       | every edge, `4rem`           |
+| `scroll-fade-b-16`     | bottom edge, `4rem`          |
+| `scroll-fade-b-[4rem]` | bottom edge, arbitrary value |
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueScrollFadeSize
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/scroll-fade/ExampleVueScrollFadeSize.vue
+::
+:::
+
+### Horizontal
+
+`scroll-fade-x` fades both inline edges of a horizontal scroller — a filter row, a tag strip, a carousel. The logical variants (`-s`, `-e`) follow the writing direction, so they swap sides under `dir="rtl"`.
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueScrollFadeHorizontal
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/scroll-fade/ExampleVueScrollFadeHorizontal.vue
+::
+:::
+
+## How it works
+
+The utility sets a CSS mask built from custom properties, and drives those properties with a scroll-linked animation:
+
+```css
+animation-timeline: scroll(self y);
+animation-range: calc(100% - var(--scroll-fade-reveal)) 100%;
+```
+
+Two things follow from that.
+
+::alert
+**Browsers without scroll-driven animations** (Firefox before 144, Safari before 26) take an `@supports not` fallback: the declared edges fade at a constant size instead of reacting to scroll position. The content still reads correctly — the fade simply does not come and go.
+::
+
+The reveal distance — how much scrolling it takes for an edge to reach full fade — is `--scroll-fade-reveal`, `6rem` by default. Override it, or the fade size, per element:
+
+```vue
+<div class="overflow-y-auto scroll-fade" style="--scroll-fade-reveal: 2rem">
+```
+
+## Scrollbars
+
+The scrollbar utilities pair with `scroll-fade` and are documented on their own page: [scrollbar](/utilities/scrollbar).

--- a/docs/content/4.utilities/scrollbar.md
+++ b/docs/content/4.utilities/scrollbar.md
@@ -1,0 +1,51 @@
+---
+navBadges:
+  - value: New
+    type: lime
+description: 'Thin, hidden or transparent scrollbars, and a stable gutter, across Firefox and WebKit.'
+badges:
+  - value: Source
+    icon: radix-icons:github-logo
+    to: https://github.com/una-ui/una-ui/blob/main/packages/preset/src/_rules/scrollbar.ts
+    target: _blank
+---
+
+Scrollbar utilities for any scroll container. Each one sets both the standard properties (`scrollbar-width`, `scrollbar-color`) and the WebKit pseudo-elements, so Firefox and Chromium/Safari agree.
+
+| Class                         | Effect                                                           |
+| ----------------------------- | ---------------------------------------------------------------- |
+| `scrollbar-thin`              | Thin scrollbar — `8px` in WebKit.                                |
+| `scrollbar-none`              | Hides the scrollbar; the container still scrolls.                |
+| `no-scrollbar`                | Alias of `scrollbar-none`.                                       |
+| `scrollbar-gutter-stable`     | Reserves the gutter, so content does not shift when it appears.  |
+| `scrollbar-thumb-transparent` | Makes the thumb transparent.                                     |
+| `scrollbar-track-transparent` | Makes the track transparent.                                     |
+| `contain-content`             | `contain: content` — an isolation hint for long, busy scrollers. |
+
+## Examples
+
+### Basic
+
+:::CodeGroup
+::div{label="Preview" preview}
+:ExampleVueScrollbarBasic
+::
+::div{label="Code"}
+@@@ ./components/content/examples/vue/scrollbar/ExampleVueScrollbarBasic.vue
+::
+:::
+
+### Hiding the scrollbar while scrolling
+
+The transparent utilities are variant-composable, which is how [MessageScroller](/components/message-scroller) fades its scrollbar out during an autoscroll and back in when the reader takes over:
+
+```vue
+<div
+  class="overflow-y-auto scrollbar-thin data-[autoscrolling]:scrollbar-thumb-transparent"
+  :data-autoscrolling="autoscrolling ? '' : undefined"
+/>
+```
+
+::alert
+`scrollbar-none` removes the affordance, not the scrolling. Keep a visible cue — a [`scroll-fade`](/utilities/scroll-fade) edge, or a scroll button — so it is still clear there is more to read.
+::


### PR DESCRIPTION
Stacked on [#623](https://github.com/una-ui/una-ui/pull/623) → [#620](https://github.com/una-ui/una-ui/pull/620); retarget as those merge. Closes #618, closes #619.

## Component page

`/components/message-scroller`, with six live examples: basic, following the live edge, anchoring turns, loading older history, scroll buttons, and jumping to messages. All built from plain markup — no dependency on the chat components (`Message`, `Bubble`, `Marker`, `Attachment`) that this map ruled out of scope, so the page stands on its own until that family lands.

Two things the examples encode on purpose:

- The streaming demo mutates **through the array proxy**. Assigning through a reference captured earlier is the easy way to make a stream look frozen, and the page calls that out.
- The jump demo puts its controls in a child component, because the composables read the provider's context — they cannot be called from the component that renders the provider itself.

## Utilities section

New top-level `Utilities` section, matching how the source groups these, with `/utilities/scroll-fade` and `/utilities/scrollbar`. Both utilities work on any scroll container with no component attached, which is why they are documented away from MessageScroller even though it is their first consumer. The scroll-fade page documents the edge/size/logical variants, the `--scroll-fade-reveal` knob, and the `@supports not` fallback for browsers without scroll-driven animations.

All three pages carry a `New` nav badge, and the example buttons use `outline-gray`.

## Verified

Rendered against the docs dev server: the page mounts 5 live scrollers and 7 buttons, all sections present, the Utilities section appears in the sidebar, `scrollToMessage` moves the viewport (0 → 1152px), and the visibility line updates as you scroll (`current turn: q1 · visible: 2 → 3`). eslint clean.

