### PR TITLE
fix: restore broken Star History chart in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 ## 🌠 Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
 </picture>
 
 ## 🌻 Sponsors

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -22,9 +22,9 @@
 ## 🌠 Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
 </picture>
 
 ## 🌻 Sponsors

--- a/packages/preset/README.md
+++ b/packages/preset/README.md
@@ -22,9 +22,9 @@
 ## 🌠 Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
 </picture>
 
 ## 🌻 Sponsors


### PR DESCRIPTION
The Star History chart in the READMEs is currently broken because of GitHub stargazer API restrictions, so the project's growth is no longer displayed. This change points the chart to a working source to bring it back across the root, preset, and nuxt package READMEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Star History charts in the documentation to use the new hosting domain.
  - Updated dark-mode, light-mode, and fallback chart image links across the main, Nuxt, and preset documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->