### PR TITLE
fix(Checkbox): make space between checkbox and label clickable

### DIFF
--- a/packages/nuxt/playground/pages/components/checkbox.vue
+++ b/packages/nuxt/playground/pages/components/checkbox.vue
@@ -15,5 +15,7 @@ const indeterminate = ref<boolean | 'indeterminate'>('indeterminate')
     />
 
     <NCheckbox v-model="checkedWithDisabled" disabled label="Checkbox" />
+
+    <NCheckbox v-model="checked" reverse label="Reverse" />
   </div>
 </template>

--- a/packages/nuxt/src/runtime/components/forms/Checkbox.vue
+++ b/packages/nuxt/src/runtime/components/forms/Checkbox.vue
@@ -75,7 +75,10 @@ const id = computed(() => props.id ?? randomId('checkbox'))
     <Label
       v-if="$slots.default || label"
       :for="props.for || id"
-      :class="cn('checkbox-label', una?.checkboxLabel)"
+      :class="cn(
+        reverse ? 'checkbox-label-reverse' : 'checkbox-label',
+        una?.checkboxLabel,
+      )"
       v-bind="props._label"
     >
       <slot>

--- a/packages/preset/src/_shortcuts/checkbox.ts
+++ b/packages/preset/src/_shortcuts/checkbox.ts
@@ -7,11 +7,12 @@ type CheckboxPrefix = 'checkbox'
 export const staticCheckbox: Record<`${CheckboxPrefix}-${string}` | CheckboxPrefix, string> = {
   // base
   'checkbox': 'checkbox-primary text-md w-1em h-1em shrink-0 rounded-sm ring-offset-base focus-visible:outline-none disabled:n-disabled border border-brand bg-brand text-inverted focus-visible:(ring-2 ring-brand ring-offset-2) data-[state=unchecked]:(bg-base text-base)',
-  'checkbox-label': 'block',
+  'checkbox-label': 'block ps-3',
+  'checkbox-label-reverse': 'block pe-3',
   'checkbox-reverse': 'flex-row-reverse',
 
   // wrappers
-  'checkbox-wrapper': 'gap-x-3 relative inline-flex items-center hover:cursor-pointer',
+  'checkbox-wrapper': 'relative inline-flex items-center hover:cursor-pointer',
 
   // icon
   'checkbox-indicator': 'flex items-center justify-center h-full w-full data-[state=unchecked]:opacity-0 transition-base opacity-100 text-inverted',


### PR DESCRIPTION
## 🔗 Linked issue

Closes #641

## ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

## 📚 Description

Clicking the space between the checkbox and its label did nothing, even though the wrapper shows a pointer cursor. The space was a `gap-x-3` on the wrapper div, so clicks there hit the wrapper — no click target.

This moves the spacing into the label itself (`ps-3`, or `pe-3` when `reverse`), the same way the Reka UI examples pad the label. The space now belongs to the label, so clicking it toggles the checkbox through the native `for` association — no JS involved.

- `checkbox-wrapper`: dropped `gap-x-3`
- `checkbox-label`: `block` → `block ps-3`
- new `checkbox-label-reverse`: `block pe-3`, applied instead of `checkbox-label` when `reverse` is set (mutually exclusive, so no CSS-order conflicts; `una.checkboxLabel` overrides still win via twMerge)
- playground: added a `reverse` checkbox example

Verified in the playground: gap click toggles in normal and reverse orientation, disabled checkbox ignores gap clicks, visual spacing unchanged (12px), logical properties keep RTL correct.

## 📝 Checklist

- [x] I have linked an issue or discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reversing checkbox label placement with appropriate directional spacing.
  * Updated the checkbox playground to demonstrate the reverse label option.

* **Bug Fixes**
  * Improved checkbox label styling to correctly adapt when the reverse option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->