### PR TITLE
fix(Checkbox): make space between checkbox and label clickable (v1)

### DIFF
--- a/packages/nuxt/playground/pages/components/checkbox.vue
+++ b/packages/nuxt/playground/pages/components/checkbox.vue
@@ -15,5 +15,7 @@ const indeterminate = ref<boolean | 'indeterminate'>('indeterminate')
     />
 
     <NCheckbox v-model="checkedWithDisabled" disabled label="Checkbox" />
+
+    <NCheckbox v-model="checked" reverse label="Reverse" />
   </div>
 </template>

--- a/packages/nuxt/src/runtime/components/forms/Checkbox.vue
+++ b/packages/nuxt/src/runtime/components/forms/Checkbox.vue
@@ -77,7 +77,10 @@ const id = computed(() => props.id ?? randomId('checkbox'))
     <Label
       v-if="$slots.default || label"
       :for="props.for || id"
-      :class="cn('checkbox-label', una?.checkboxLabel)"
+      :class="cn(
+        reverse ? 'checkbox-label-reverse' : 'checkbox-label',
+        una?.checkboxLabel,
+      )"
       v-bind="props._label"
     >
       <slot>

--- a/packages/preset/src/_shortcuts/checkbox.ts
+++ b/packages/preset/src/_shortcuts/checkbox.ts
@@ -3,11 +3,12 @@ type CheckboxPrefix = 'checkbox'
 export const staticCheckbox: Record<`${CheckboxPrefix}-${string}` | CheckboxPrefix, string> = {
   // base
   'checkbox': 'dark:bg-input/30 square-1em shrink-0 rounded-4px shadow-xs transition-shadow outline-none disabled:n-disabled border border-input dark:border-input',
-  'checkbox-label': 'block',
+  'checkbox-label': 'block ps-3',
+  'checkbox-label-reverse': 'block pe-3',
   'checkbox-reverse': 'flex-row-reverse',
 
   // wrappers
-  'checkbox-wrapper': 'gap-x-3 relative inline-flex items-center hover:cursor-pointer',
+  'checkbox-wrapper': 'relative inline-flex items-center hover:cursor-pointer',
 
   // icon
   'checkbox-indicator': 'flex items-center justify-center text-primary-foreground transition-none',


### PR DESCRIPTION
## 🔗 Linked issue

Port of #642 to the `v1.0.0` branch (issue #641, already closed by the main PR).

## ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

## 📚 Description

Cherry-pick of 79490256 onto `v1.0.0` — same fix, adapted to the v1 checkbox shortcuts (kept the v1 `checkbox` base string in the conflict).

The space between checkbox and label was a `gap-x-3` on the wrapper div, so clicks there hit nothing. The spacing now lives in the label (`ps-3`, or `pe-3` when `reverse`), so clicking it toggles the checkbox through the native `for` association.

- `checkbox-wrapper`: dropped `gap-x-3`
- `checkbox-label`: `block` → `block ps-3`
- new `checkbox-label-reverse`: `block pe-3`, applied instead of `checkbox-label` when `reverse` is set
- playground: added a `reverse` checkbox example

Verified in the v1 playground: gap click toggles in normal and reverse orientation, visual spacing unchanged (12px).

## 📝 Checklist

- [x] I have linked an issue or discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)