### PR TITLE
docs: restore Star History chart in READMEs (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 ## 🌠 Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
 </picture>
 
 ## 🌻 Sponsors

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -22,9 +22,9 @@
 ## 🌠 Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
 </picture>
 
 ## 🌻 Sponsors

--- a/packages/preset/README.md
+++ b/packages/preset/README.md
@@ -22,9 +22,9 @@
 ## 🌠 Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=una-ui/una-ui&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=una-ui/una-ui&type=Date" />
 </picture>
 
 ## 🌻 Sponsors


### PR DESCRIPTION
## 🔗 Linked issue

Port of #626 to the `v1.0.0` branch.

## ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)

## 📚 Description

Clean cherry-pick of 42a78b18 (`-x`, no conflicts). Brings the working Star History chart source to the v1 READMEs.

With this, `v1.0.0` carries every portable main commit — the only remaining `v1.0.0..main` deltas are 0.x release bumps, which stay main-only by design.

## 📝 Checklist

- [x] I have linked an issue or discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)